### PR TITLE
build: update guard path

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,7 +12,7 @@ option('HW_ISOLATION_OBJPATH', type: 'string',
       )
 
 option('PHAL_DEVTREE', type: 'string',
-        value : '/var/lib/phosphor-software-manager/pnor/rw/DEVTREE',
+        value : '/var/lib/phosphor-software-manager/hostfw/running/GUARD',
         description : 'The PHAL CEC device tree to get hardware details'
       )
 


### PR DESCRIPTION
The pnor directories are being replaced with the hostfw
"/var/lib/phosphor-software-manager/hostfw/running/GUARD"
directories that are handled by PLDM.
