### PR TITLE
record: manager: Fix: Clear entries if no record

### DIFF
--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -427,6 +427,14 @@ void Manager::handleHostIsolatedHardwares()
 
     openpower_guard::GuardRecords records = openpower_guard::getAll();
 
+    // Delete all the D-Bus entries if no record in their persisted location
+    if ((records.size() == 0) && _isolatedHardwares.size() > 0)
+    {
+        _isolatedHardwares.clear();
+        _lastEntryId = 0;
+        return;
+    }
+
     std::for_each(records.begin(), records.end(), [this](const auto& record) {
         // Skipping fake record (GARD_Reconfig) because, fake record is
         // created for internal purposes to use by BMC and Hostboot.


### PR DESCRIPTION
Currently, the hardware isolation record D-bus entries are not cleared
if someone cleared (aka reset) all the records by using the "guard -r"
so fixes that issue in this patch.

Tested:

- Without fix.

```
root@rain98bmc:~# guard -c physical:sys-0/node-0/dimm-0

root@rain98bmc:~# guard -l
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/dimm-0

root@rain98bmc:~# busctl tree org.open_power.HardwareIsolation
└─/xyz
  └─/xyz/openbmc_project
    └─/xyz/openbmc_project/hardware_isolation
      └─/xyz/openbmc_project/hardware_isolation/entry
        └─/xyz/openbmc_project/hardware_isolation/entry/1

root@rain98bmc:~# guard -r

root@rain98bmc:~# guard -l
No Records to display

root@rain98bmc:~# busctl tree org.open_power.HardwareIsolation
└─/xyz
  └─/xyz/openbmc_project
    └─/xyz/openbmc_project/hardware_isolation
      └─/xyz/openbmc_project/hardware_isolation/entry
        └─/xyz/openbmc_project/hardware_isolation/entry/1
```

- With fix.

```
root@rain98bmc:~# guard -c physical:sys-0/node-0/dimm-0

root@rain98bmc:~# guard -l
ID       | ERROR    |  Type  | Path
00000001 | 00000000 | manual | physical:sys-0/node-0/dimm-0

root@rain98bmc:~# busctl tree org.open_power.HardwareIsolation
└─/xyz
  └─/xyz/openbmc_project
    └─/xyz/openbmc_project/hardware_isolation
      └─/xyz/openbmc_project/hardware_isolation/entry
        └─/xyz/openbmc_project/hardware_isolation/entry/1

root@rain98bmc:~# guard -r

root@rain98bmc:~# guard -l
No Records to display

root@rain98bmc:~# busctl tree org.open_power.HardwareIsolation
└─/xyz
  └─/xyz/openbmc_project
    └─/xyz/openbmc_project/hardware_isolation
```