### PR TITLE
Add Generic_I2C_Device, PMIC, and OSCREFCLK targets

### DIFF
--- a/include/common/isolatable_hardwares.hpp
+++ b/include/common/isolatable_hardwares.hpp
@@ -348,6 +348,33 @@ class IsolatableHWs
     std::optional<sdbusplus::message::object_path> getFRUInventoryPath(
         const std::pair<LocationCode, InstanceId>& fruDetails,
         const inv_path_lookup_func::LookupFuncForInvPath& fruInvPathLookupFunc);
+
+    /**
+     * @brief Used to get the clock parent fru inventory object path
+     *
+     * @param[in] clkTgt - The clock target to get parent fru path
+     *
+     * @return The clock parent fru inventory object path on success
+     *         Empty optional on failure
+     *
+     * @note The oscrefclk parent fru is not modelled in the phal cec
+     *       device tree so defining the temporary workaround in this API
+     *       instead of defining the isolatable hardwares list.
+     */
+    std::optional<sdbusplus::message::object_path>
+        getClkParentFruObjPath(struct pdbg_target* clkTgt);
+
+    /**
+     * @brief Used to get the parent fru inventory object path of the given
+     *        child target (aka phal cec device tree target)
+     *
+     * @param[in] childTgt - The child target to get parent fru path
+     *
+     * @return The parent fru inventory object path on success
+     *         Empty optional on failure
+     */
+    std::optional<sdbusplus::message::object_path>
+        getParentFruObjPath(struct pdbg_target* childTgt);
 };
 
 } // namespace isolatable_hws

--- a/src/common/isolatable_hardwares.cpp
+++ b/src/common/isolatable_hardwares.cpp
@@ -15,6 +15,8 @@ using namespace phosphor::logging;
 namespace isolatable_hws
 {
 
+constexpr auto CommonInventoryItemIface = "xyz.openbmc_project.Inventory.Item";
+
 IsolatableHWs::IsolatableHWs(sdbusplus::bus::bus& bus) : _bus(bus)
 {
     /**
@@ -52,8 +54,7 @@ IsolatableHWs::IsolatableHWs(sdbusplus::bus::bus& bus) : _bus(bus)
 
         // Processor Subunits
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "eq"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "eq"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "Quad")},
@@ -75,107 +76,91 @@ IsolatableHWs::IsolatableHWs(sdbusplus::bus::bus& bus) : _bus(bus)
 
         // In BMC inventory, ECO mode core is modeled as a subunit since it
         // is not the normal core
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "core"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "core"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "Cache-Only Core")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "mc"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "mc"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "Memory Controller")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "mi"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "mi"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "Processor To Memory Buffer Interface")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "mcc"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "mcc"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "Memory Controller Channel")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "omi"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "omi"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "OpenCAPI Memory Interface")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "pauc"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "pauc"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "POWER Accelerator Unit Controller")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "pau"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "pau"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "POWER Accelerator Unit")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "omic"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "omic"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "OpenCAPI Memory Interface Controller")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "iohs"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "iohs"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "High speed SMP/OpenCAPI Link")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "smpgroup"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "smpgroup"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "OBUS End Point")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "pec"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "pec"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "PCI Express controllers")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "phb"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "phb"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::chipUnitPos,
              inv_path_lookup_func::itemPrettyName, "PCIe host bridge (PHB)")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "nmmu"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "nmmu"),
          IsolatableHWs::HW_Details(!ItIsFRU, processorHwId,
                                    devtree::lookup_func::chipUnitPos,
                                    inv_path_lookup_func::itemPrettyName,
                                    "Nest Memory Management Unit")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "nx"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "nx"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, processorHwId, devtree::lookup_func::mruId,
              inv_path_lookup_func::itemPrettyName, "Accelerator")},
 
         // Memory (aka DIMM) subunits
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "ocmb"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "ocmb"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, dimmHwId, devtree::lookup_func::pdbgIndex,
              inv_path_lookup_func::itemPrettyName, "OpenCAPI Memory Buffer")},
 
-        {IsolatableHWs::HW_Details::HwId("xyz.openbmc_project.Inventory.Item",
-                                         "mem_port"),
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "mem_port"),
          IsolatableHWs::HW_Details(
              !ItIsFRU, dimmHwId, devtree::lookup_func::pdbgIndex,
              inv_path_lookup_func::itemPrettyName, "DDR Memory Port")},
@@ -882,47 +867,49 @@ std::optional<sdbusplus::message::object_path> IsolatableHWs::getInventoryPath(
                 return std::nullopt;
             }
 
-            InstanceId isolateHwInstId;
-            // TODO Below decision need to be based on system core mode
-            //     i.e whether need to use "fc" (in big core system) or
-            //     "core" (in small core system) pdbg target class to get
-            //     the appropriate target physical path from the phal
-            //     cec device tree but, now using the "fc".
-            if (isolatedHwPdbgClass == "core")
-            {
-                struct pdbg_target* parentFc =
-                    pdbg_target_parent("fc", *isolatedHwTgt);
-                if (parentFc == nullptr)
-                {
-                    log<level::ERR>(
-                        fmt::format("Failed to get the parent FC target for "
-                                    "the given device tree target path [{}]",
-                                    isolatedHwTgtDevTreePath)
-                            .c_str());
-                    return std::nullopt;
-                }
-                isolateHwInstId = devtree::getHwInstIdFromDevTree(parentFc);
-            }
-            else
-            {
-                isolateHwInstId =
-                    devtree::getHwInstIdFromDevTree(*isolatedHwTgt);
-            }
-
             /**
-             * If PrettyName is not empty then use that as unique hardware id
-             * because currently few isolatbale hardware subunits is not
-             * modelled in BMC Inventory and Redfish so these subunits
-             * need to look based on PrettyName to get inventory path.
+             * If the isolated hardware inventory item interface is
+             * CommonInventoryItemIface ("xyz.openbmc_project.Inventory.Item")
+             * then, use PrettyName as unique hardware id because currently
+             * few isolatbale hardware subunits is not modelled in the BMC
+             * Inventory and Redfish so those subunits need to look based on
+             * the PrettyName to get inventory path.
              */
             inv_path_lookup_func::UniqueHwId uniqIsolateHwKey;
-            if (!isolatedHwDetails->second._prettyName.empty())
+            if (isolatedHwDetails->first._interfaceName._name ==
+                CommonInventoryItemIface)
             {
                 uniqIsolateHwKey = isolatedHwDetails->second._prettyName;
             }
             else
             {
-                uniqIsolateHwKey = isolateHwInstId;
+                // TODO Below decision need to be based on system core mode
+                //     i.e whether need to use "fc" (in big core system) or
+                //     "core" (in small core system) pdbg target class to get
+                //     the appropriate target physical path from the phal
+                //     cec device tree but, now using the "fc".
+                if (isolatedHwPdbgClass == "core")
+                {
+                    struct pdbg_target* parentFc =
+                        pdbg_target_parent("fc", *isolatedHwTgt);
+                    if (parentFc == nullptr)
+                    {
+                        log<level::ERR>(
+                            fmt::format("Failed to get the parent FC "
+                                        "target for the given device tree "
+                                        "target path [{}]",
+                                        isolatedHwTgtDevTreePath)
+                                .c_str());
+                        return std::nullopt;
+                    }
+                    uniqIsolateHwKey =
+                        devtree::getHwInstIdFromDevTree(parentFc);
+                }
+                else
+                {
+                    uniqIsolateHwKey =
+                        devtree::getHwInstIdFromDevTree(*isolatedHwTgt);
+                }
             }
 
             auto isolateHwPath = std::find_if(

--- a/src/common/isolatable_hardwares.cpp
+++ b/src/common/isolatable_hardwares.cpp
@@ -178,6 +178,12 @@ IsolatableHWs::IsolatableHWs(sdbusplus::bus::bus& bus) : _bus(bus)
                                    devtree::lookup_func::pdbgIndex,
                                    inv_path_lookup_func::itemPrettyName,
                                    "Onboard Memory Power Control Device")},
+
+        {IsolatableHWs::HW_Details::HwId(CommonInventoryItemIface, "pmic"),
+         IsolatableHWs::HW_Details(!ItIsFRU, dimmHwId,
+                                   devtree::lookup_func::pdbgIndex,
+                                   inv_path_lookup_func::itemPrettyName,
+                                   "Onboard Memory Power Management IC")},
     };
 }
 
@@ -590,23 +596,25 @@ std::optional<struct pdbg_target*>
 
     struct pdbg_target* parentFruTarget = nullptr;
     if ((fruUnitPdbgClass == "ocmb") || (fruUnitPdbgClass == "mem_port") ||
-        (fruUnitPdbgClass == "adc") || (fruUnitPdbgClass == "gpio_expander"))
+        (fruUnitPdbgClass == "adc") || (fruUnitPdbgClass == "gpio_expander") ||
+        (fruUnitPdbgClass == "pmic"))
     {
         /**
          * FIXME: The assumption is, dimm is parent fru for "ocmb", "mem_port",
-         *        "adc", and "gpio_expander" units and those units
+         *        "adc", "gpio_expander", and "pmic" units and those units
          *        will have only one "dimm" so if something is changed then,
          *        need to fix this logic.
          * @note  In phal cec device tree dimm is placed under ocmb->mem_port
          *        based on dimm pervasive path.
          */
         if ((fruUnitPdbgClass == "adc") ||
-            (fruUnitPdbgClass == "gpio_expander"))
+            (fruUnitPdbgClass == "gpio_expander") ||
+            (fruUnitPdbgClass == "pmic"))
         {
             /**
-             * The "adc", and "gpio_expander" units are placed under ocmb
-             * but, dimm is placed under the ocmb so, we need to get
-             * the parent ocmb for the given "adc", and "gpio_expander"
+             * The "adc", "gpio_expander", and "pmic" units are placed under
+             * ocmb but, dimm is placed under the ocmb so, we need to get the
+             * parent ocmb for the given "adc", "gpio_expander", and "pmic"
              * units to get the dimm fru target.
              */
             devTreeTgt = pdbg_target_parent("ocmb", devTreeTgt);


### PR DESCRIPTION
Please review the last 4 patches since the remaining patches are added for different purposes and these patches included in the separate PR https://github.com/ibm-openbmc/openpower-hw-isolation/pull/10