### PR TITLE
record: Update the hardware isolation D-Bus entries if overridden

### DIFF
--- a/include/hw_isolation_record/manager.hpp
+++ b/include/hw_isolation_record/manager.hpp
@@ -209,6 +209,27 @@ class Manager :
                     const openpower_guard::EntityPath& entityPath);
 
     /**
+     * @brief Update a entry dbus object for isolated hardware if exists
+     *
+     * @param[in] recordId - the isolated hardware record id
+     * @param[in] severity - the severity of hardware isolation
+     * @param[in] isolatedHwDbusObjPath - the isolated hardware D-Bus object
+     *                                    path
+     * @param[in] bmcErrorLog - The error log which caused the hardware
+     *                          isolation
+     * @param[in] entityPath - the isolated hardware entity path
+     *
+     * @return pair<true, object_path> on success
+     *         pair<false, ""> on failure
+     */
+    std::pair<bool, sdbusplus::message::object_path>
+        updateEntry(const entry::EntryRecordId& recordId,
+                    const entry::EntrySeverity& severity,
+                    const std::string& isolatedHwDbusObjPath,
+                    const std::string& bmcErrorLog,
+                    const openpower_guard::EntityPath& entityPath);
+
+    /**
      * @brief Used to get to know whether hardware isolation is allowed
      *
      * @param[in] severity - the severity of hardware isolation
@@ -231,6 +252,22 @@ class Manager :
      *       for all isolated hardware that is stored in the preserved location.
      */
     void createEntryForRecord(const openpower_guard::GuardRecord& record);
+
+    /**
+     * @brief Update the given dbus entry object for isolated hardware record
+     *
+     * @param[in] record - The isolated hardware record
+     * @param[out] entryIt - The dbus entry object to update
+     *
+     * @return NULL on success
+     *
+     * @note The function will skip given isolated hardware to update
+     *       dbus entry if any failure since this is restoring mechanism
+     *       so the hardware isolation application need to update dbus entries
+     *       for all isolated hardware that is stored in the preserved location.
+     */
+    void updateEntryForRecord(const openpower_guard::GuardRecord& record,
+                              IsolatedHardwares::iterator& entryIt);
 };
 
 } // namespace record

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -124,6 +124,62 @@ std::optional<sdbusplus::message::object_path> Manager::createEntry(
     return std::nullopt;
 }
 
+std::pair<bool, sdbusplus::message::object_path> Manager::updateEntry(
+    const entry::EntryRecordId& recordId, const entry::EntrySeverity& severity,
+    const std::string& isolatedHwDbusObjPath, const std::string& bmcErrorLog,
+    const openpower_guard::EntityPath& entityPath)
+{
+    auto isolatedHwIt = std::find_if(
+        _isolatedHardwares.begin(), _isolatedHardwares.end(),
+        [recordId, entityPath](const auto& isolatedHw) {
+            return ((isolatedHw.second->getEntityPath() == entityPath) &&
+                    (isolatedHw.second->getEntryRecId() == recordId) &&
+                    (!isolatedHw.second->resolved()));
+        });
+
+    if (isolatedHwIt == _isolatedHardwares.end())
+    {
+        // D-Bus entry does not exist
+        return std::make_pair(false, std::string());
+    }
+
+    // Add association for isolated hardware inventory path
+    // Note: Association forward and reverse type are defined as per
+    // hardware isolation design document (aka guard) and hardware isolation
+    // entry dbus interface document for hardware and error object path
+    type::AsscDefFwdType isolateHwFwdType("isolated_hw");
+    type::AsscDefRevType isolatedHwRevType("isolated_hw_entry");
+    type::AssociationDef associationDeftoHw;
+    associationDeftoHw.push_back(std::make_tuple(
+        isolateHwFwdType, isolatedHwRevType, isolatedHwDbusObjPath));
+
+    // Add errog log as Association if given
+    if (!bmcErrorLog.empty())
+    {
+        type::AsscDefFwdType bmcErrorLogFwdType("isolated_hw_errorlog");
+        type::AsscDefRevType bmcErrorLogRevType("isolated_hw_entry");
+        associationDeftoHw.push_back(std::make_tuple(
+            bmcErrorLogFwdType, bmcErrorLogRevType, bmcErrorLog));
+    }
+
+    // Existing record might be overridden in the libguard during
+    // creation if that's meets certain override conditions
+    if (isolatedHwIt->second->severity() != severity)
+    {
+        isolatedHwIt->second->severity(severity);
+    }
+
+    if (isolatedHwIt->second->associations() != associationDeftoHw)
+    {
+        isolatedHwIt->second->associations(associationDeftoHw);
+    }
+
+    auto entryObjPath = fs::path(HW_ISOLATION_ENTRY_OBJPATH) /
+                        std::to_string(isolatedHwIt->first);
+
+    return std::make_pair(true, entryObjPath.string());
+}
+
 void Manager::isHwIsolationAllowed(const entry::EntrySeverity& severity)
 {
     // Make sure the hardware isolation setting is enabled or not
@@ -184,15 +240,24 @@ sdbusplus::message::object_path Manager::create(
     auto guardRecord =
         openpower_guard::create(devTreePhysicalPath->data(), 0, *guardType);
 
-    auto entryPath =
-        createEntry(guardRecord->recordId, false, severity, isolateHardware.str,
-                    "", true, guardRecord->targetId);
-
-    if (!entryPath.has_value())
+    if (auto ret = updateEntry(guardRecord->recordId, severity,
+                               isolateHardware.str, "", guardRecord->targetId);
+        ret.first == true)
     {
-        throw type::CommonError::InternalFailure();
+        return ret.second;
     }
-    return *entryPath;
+    else
+    {
+        auto entryPath =
+            createEntry(guardRecord->recordId, false, severity,
+                        isolateHardware.str, "", true, guardRecord->targetId);
+
+        if (!entryPath.has_value())
+        {
+            throw type::CommonError::InternalFailure();
+        }
+        return *entryPath;
+    }
 }
 
 sdbusplus::message::object_path Manager::createWithErrorLog(
@@ -234,15 +299,25 @@ sdbusplus::message::object_path Manager::createWithErrorLog(
     auto guardRecord =
         openpower_guard::create(devTreePhysicalPath->data(), *eId, *guardType);
 
-    auto entryPath =
-        createEntry(guardRecord->recordId, false, severity, isolateHardware.str,
-                    bmcErrorLog.str, true, guardRecord->targetId);
-
-    if (!entryPath.has_value())
+    if (auto ret =
+            updateEntry(guardRecord->recordId, severity, isolateHardware.str,
+                        bmcErrorLog.str, guardRecord->targetId);
+        ret.first == true)
     {
-        throw type::CommonError::InternalFailure();
+        return ret.second;
     }
-    return *entryPath;
+    else
+    {
+        auto entryPath = createEntry(guardRecord->recordId, false, severity,
+                                     isolateHardware.str, bmcErrorLog.str, true,
+                                     guardRecord->targetId);
+
+        if (!entryPath.has_value())
+        {
+            throw type::CommonError::InternalFailure();
+        }
+        return *entryPath;
+    }
 }
 
 void Manager::deleteAll()
@@ -359,6 +434,88 @@ void Manager::createEntryForRecord(const openpower_guard::GuardRecord& record)
     }
 }
 
+void Manager::updateEntryForRecord(const openpower_guard::GuardRecord& record,
+                                   IsolatedHardwares::iterator& entryIt)
+{
+    auto entityPathRawData =
+        devtree::convertEntityPathIntoRawData(record.targetId);
+    std::stringstream ss;
+    std::for_each(entityPathRawData.begin(), entityPathRawData.end(),
+                  [&ss](const auto& ele) {
+                      ss << std::setw(2) << std::setfill('0') << std::hex
+                         << (int)ele << " ";
+                  });
+
+    auto isolatedHwInventoryPath =
+        _isolatableHWs.getInventoryPath(entityPathRawData);
+
+    if (!isolatedHwInventoryPath.has_value())
+    {
+        log<level::ERR>(
+            fmt::format("Skipping to restore a given isolated "
+                        "hardware [{}] : Due to failure to get inventory path",
+                        ss.str())
+                .c_str());
+        return;
+    }
+
+    auto bmcErrorLogPath = utils::getBMCLogPath(_bus, record.elogId);
+
+    if (!bmcErrorLogPath.has_value())
+    {
+        log<level::ERR>(
+            fmt::format(
+                "Skipping to restore a given isolated "
+                "hardware [{}] : Due to failure to get BMC error log path "
+                "by isolated hardware EID (aka PEL ID) [{}]",
+                ss.str(), record.elogId)
+                .c_str());
+        return;
+    }
+
+    auto entrySeverity = entry::utils::getEntrySeverityType(
+        static_cast<openpower_guard::GardType>(record.errType));
+    if (!entrySeverity.has_value())
+    {
+        log<level::ERR>(
+            fmt::format("Skipping to restore a given isolated "
+                        "hardware [{}] : Due to failure to to get BMC "
+                        "EntrySeverity by isolated hardware GardType [{}]",
+                        ss.str(), record.errType)
+                .c_str());
+        return;
+    }
+
+    // Add association for isolated hardware inventory path
+    // Note: Association forward and reverse type are defined as per
+    // hardware isolation design document (aka guard) and hardware isolation
+    // entry dbus interface document for hardware and error object path
+    type::AsscDefFwdType isolateHwFwdType("isolated_hw");
+    type::AsscDefRevType isolatedHwRevType("isolated_hw_entry");
+    type::AssociationDef associationDeftoHw;
+    associationDeftoHw.push_back(std::make_tuple(
+        isolateHwFwdType, isolatedHwRevType, *isolatedHwInventoryPath));
+
+    // Add errog log as Association if given
+    if (!bmcErrorLogPath->str.empty())
+    {
+        type::AsscDefFwdType bmcErrorLogFwdType("isolated_hw_errorlog");
+        type::AsscDefRevType bmcErrorLogRevType("isolated_hw_entry");
+        associationDeftoHw.push_back(std::make_tuple(
+            bmcErrorLogFwdType, bmcErrorLogRevType, *bmcErrorLogPath));
+    }
+
+    if (entryIt->second->severity() != entrySeverity)
+    {
+        entryIt->second->severity(*entrySeverity);
+    }
+
+    if (entryIt->second->associations() != associationDeftoHw)
+    {
+        entryIt->second->associations(associationDeftoHw);
+    }
+}
+
 void Manager::restore()
 {
     openpower_guard::GuardRecords records = openpower_guard::getAll();
@@ -419,11 +576,16 @@ void Manager::handleHostIsolatedHardwares()
         {
             this->createEntryForRecord(record);
         }
-        // Update Resolved property if a record is resolved otherwise skip
-        // the record since it is already exist in isolated hardware entries.
+        // Update Resolved property if a record is resolved.
         else if (record.recordId == 0xFFFFFFFF)
         {
             isolatedHwIt->second->resolved(true);
+        }
+        else
+        {
+            // Existing record might be overridden in the libguard during
+            // creation if that's meets certain override conditions
+            updateEntryForRecord(record, isolatedHwIt);
         }
     });
 }
@@ -471,15 +633,25 @@ sdbusplus::message::object_path Manager::createWithEntityPath(
     auto guardRecord =
         openpower_guard::create(entityPath.data(), *eId, *guardType);
 
-    auto entryPath = createEntry(guardRecord->recordId, false, severity,
-                                 isolateHwInventoryPath->str, bmcErrorLog.str,
-                                 true, guardRecord->targetId);
-
-    if (!entryPath.has_value())
+    if (auto ret = updateEntry(guardRecord->recordId, severity,
+                               isolateHwInventoryPath->str, bmcErrorLog.str,
+                               guardRecord->targetId);
+        ret.first == true)
     {
-        throw type::CommonError::InternalFailure();
+        return ret.second;
     }
-    return *entryPath;
+    else
+    {
+        auto entryPath = createEntry(
+            guardRecord->recordId, false, severity, isolateHwInventoryPath->str,
+            bmcErrorLog.str, true, guardRecord->targetId);
+
+        if (!entryPath.has_value())
+        {
+            throw type::CommonError::InternalFailure();
+        }
+        return *entryPath;
+    }
 }
 
 std::optional<std::tuple<entry::EntrySeverity, entry::EntryErrLogPath>>


### PR DESCRIPTION
- The libguard is changed to support overriding the hardware isolation
  record into their persisted location.

  - Override the Manual hardware isolation record by either Critical
    or Warning failures.

  - Override the Warning hardware isolation record by Critical
    failure.

- So, added the same support in the openpower-hw-isolation application
  to update the D-Bus entries.

Tested:

- Verified by creating the manual and critical isolation record on
  the same hardware.

- Verified by creating the manual and warning isolation record on
  the same hardware.

- Verified by creating the warning and critical isolation record on
  the same hardware.