### PR TITLE
Fix, Update hardware inventory "Enabled" D-Bus property

### DIFF
--- a/include/hw_isolation_record/entry.hpp
+++ b/include/hw_isolation_record/entry.hpp
@@ -81,10 +81,22 @@ class Entry :
           const openpower_guard::EntityPath& entityPath);
 
     /**
+     * @brief Mark this object as resolved
+     *
+     * @param[in] clearRecord - use to decide whether want to clear
+     *                          record from their preserved file.
+     *                          By default, it will clear record.
+     * @return NULL
+     *
+     * @note This function just resolve the entry, won't check
+     *       whether resolve operation is allowed or not like "delete_()".
+     */
+    void resolveEntry(bool clearRecord = true);
+
+    /**
      *  @brief Mark this object as resolved
      *
      *  @return NULL
-     *
      */
     void delete_() override;
 

--- a/src/hw_isolation_event/hw_status_manager.cpp
+++ b/src/hw_isolation_event/hw_status_manager.cpp
@@ -275,9 +275,13 @@ void Manager::restoreHardwaresStatusEvent()
                                  hwasState.functional)
                         {
                             /**
-                             * Event is not required since the hardware
-                             * isolation record is not exist and functional.
+                             * Event is not required and update "Enabled"
+                             * D-Bus property of the hardware because
+                             * the hardware isolation record is not exist and
+                             * functional.
                              */
+                            hw_isolation::utils::setEnabledProperty(
+                                _bus, hwInventoryPath->str, true);
                             continue;
                         }
                         else if ((hwasState.deconfiguredByEid &

--- a/src/hw_isolation_record/entry.cpp
+++ b/src/hw_isolation_record/entry.cpp
@@ -44,16 +44,14 @@ Entry::Entry(sdbusplus::bus::bus& bus, const std::string& objPath,
     this->emit_object_added();
 }
 
-void Entry::delete_()
+void Entry::resolveEntry(bool clearRecord)
 {
     if (!resolved())
     {
-        if (!hw_isolation::utils::isHwDeisolationAllowed(_bus))
+        if (clearRecord)
         {
-            throw type::CommonError::NotAllowed();
+            openpower_guard::clear(_entryRecordId);
         }
-
-        openpower_guard::clear(_entryRecordId);
         resolved(true);
         for (auto& assoc : associations())
         {
@@ -65,6 +63,15 @@ void Entry::delete_()
             }
         }
     }
+}
+
+void Entry::delete_()
+{
+    if (!hw_isolation::utils::isHwDeisolationAllowed(_bus))
+    {
+        throw type::CommonError::NotAllowed();
+    }
+    resolveEntry();
 }
 
 openpower_guard::EntityPath Entry::getEntityPath() const

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -579,10 +579,11 @@ void Manager::handleHostIsolatedHardwares()
         {
             this->createEntryForRecord(record);
         }
-        // Update Resolved property if a record is resolved.
         else if (record.recordId == 0xFFFFFFFF)
         {
-            isolatedHwIt->second->resolved(true);
+            // Update Resolved and Enabled properties respectively
+            // in the hardware isolation entry and inventory D-Bus objects
+            isolatedHwIt->second->resolveEntry(false);
         }
         else
         {


### PR DESCRIPTION

It fixes [SW541617](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW541617)

**Background:** 

- Currently, the hardware inventory "Enabled" D-Bus property showing as
  "false" even if it is functional and doesn't have hardware isolation
  record or the existing hardware isolation record resolved for the
  respective hardware inventory object.

- So, updated the hardware inventory "Enabled" D-Bus property as "true"
  if the above case occurs.

**Tested:**

- Verified the "Enabled" property during cold boot without hardware
  isolation record.

- Verified the "Enabled" property by manually resolving hardware
  isolation record.
