### PR TITLE
record: Return an appropriate error if the D-Bus request failed

### DIFF
--- a/include/common/utils.hpp
+++ b/include/common/utils.hpp
@@ -144,9 +144,10 @@ void setDBusPropertyVal(sdbusplus::bus::bus& bus, const std::string& objPath,
  *
  * @param[in] bus - Bus to attach to.
  *
- * @return False if not allowed else True
+ * @return Throw appropriate exception if not allowed
+ *         NULL if allowed
  */
-bool isHwDeisolationAllowed(sdbusplus::bus::bus& bus);
+void isHwDeisolationAllowed(sdbusplus::bus::bus& bus);
 
 /**
  * @brief Used to get to know whether hardware isolation setting is

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -88,7 +88,7 @@ bool isHwIosolationSettingEnabled(sdbusplus::bus::bus& bus)
     }
 }
 
-bool isHwDeisolationAllowed(sdbusplus::bus::bus& bus)
+void isHwDeisolationAllowed(sdbusplus::bus::bus& bus)
 {
     // Make sure the hardware isolation setting is enabled or not
     if (!isHwIosolationSettingEnabled(bus))
@@ -97,7 +97,7 @@ bool isHwDeisolationAllowed(sdbusplus::bus::bus& bus)
             fmt::format("Hardware deisolation is not allowed "
                         "since the HardwareIsolation setting is disabled")
                 .c_str());
-        return false;
+        throw type::CommonError::Unavailable();
     }
 
     using Chassis = sdbusplus::xyz::openbmc_project::State::server::Chassis;
@@ -112,9 +112,8 @@ bool isHwDeisolationAllowed(sdbusplus::bus::bus& bus)
         log<level::ERR>(fmt::format("Manual hardware de-isolation is allowed "
                                     "only when chassis powerstate is off")
                             .c_str());
-        return false;
+        throw type::CommonError::NotAllowed();
     }
-    return true;
 }
 
 void setEnabledProperty(sdbusplus::bus::bus& bus,

--- a/src/hw_isolation_record/entry.cpp
+++ b/src/hw_isolation_record/entry.cpp
@@ -67,10 +67,9 @@ void Entry::resolveEntry(bool clearRecord)
 
 void Entry::delete_()
 {
-    if (!hw_isolation::utils::isHwDeisolationAllowed(_bus))
-    {
-        throw type::CommonError::NotAllowed();
-    }
+    // throws exception if not allowed
+    hw_isolation::utils::isHwDeisolationAllowed(_bus);
+
     resolveEntry();
 }
 

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -189,7 +189,7 @@ void Manager::isHwIsolationAllowed(const entry::EntrySeverity& severity)
             fmt::format("Hardware isolation is not allowed "
                         "since the HardwareIsolation setting is disabled")
                 .c_str());
-        throw type::CommonError::NotAllowed();
+        throw type::CommonError::Unavailable();
     }
 
     if (severity == entry::EntrySeverity::Manual)
@@ -322,10 +322,8 @@ sdbusplus::message::object_path Manager::createWithErrorLog(
 
 void Manager::deleteAll()
 {
-    if (!hw_isolation::utils::isHwDeisolationAllowed(_bus))
-    {
-        throw type::CommonError::NotAllowed();
-    }
+    // throws exception if not allowed
+    hw_isolation::utils::isHwDeisolationAllowed(_bus);
 
     auto entryIt = _isolatedHardwares.begin();
     while (entryIt != _isolatedHardwares.end())

--- a/src/hw_isolation_record/openpower_guard_interface.cpp
+++ b/src/hw_isolation_record/openpower_guard_interface.cpp
@@ -58,7 +58,7 @@ namespace HardwareIsolationError =
     }                                                                          \
     catch (libguard::exception::GuardFileOverFlowed & e)                       \
     {                                                                          \
-        throw type::CommonError::NotAllowed();                                 \
+        throw type::CommonError::TooManyResources();                           \
     }
 
 std::optional<GuardRecord> create(const EntityPath& entityPath,


### PR DESCRIPTION
- The hardware isolation D-bus request might be triggered by the application
  that might act as an external user interface like a redfish server so
  the redfish server need to return the appropriate error to the end
  user if the end-user request failed.

- Currently, the hardware isolation returning "NotAllowed" error in the
  below cases but, the user might need to take some action based on the
  error.

  - Returns "NotAllowed" error when the manual hardware isolation request
    is not allowed during host power on or running.

  - Returns "NotAllowed" error when the hardware isolation service is disabled
    by using the "allow_hw_isolation" settings.

  - Returns "NotAllowed" error when the hardware isolation record file is full.

- Fixing the above case by returning a different error.

  - Returns "NotAllowed" error when the manual hardware isolation request
    is not allowed during host power on or running.

  - Returns "Unavailable" error when the hardware isolation service is
    disabled by using the "allow_hw_isolation" settings.

  - Returns "TooManyResources" error when the hardware isolation record file
    is fulled.

Tested:

 - Verified by creating the hardware isolation record during system running.

 - Verified by creating the hardware isolation record when the "allow_hw_isolation"
   setting is disabled.

 - Verified by creating more hardware isolation records.