### PR TITLE
record: Don't allow the user to delete the system isolated hw entry

### DIFF
--- a/src/hw_isolation_record/entry.cpp
+++ b/src/hw_isolation_record/entry.cpp
@@ -70,6 +70,16 @@ void Entry::delete_()
     // throws exception if not allowed
     hw_isolation::utils::isHwDeisolationAllowed(_bus);
 
+    // throws exception if the user tried deisolate the system
+    // isolated hardware entry
+    if (severity() != EntrySeverity::Manual)
+    {
+        log<level::ERR>(fmt::format("User is not allowed to clear the system "
+                                    "isolated hardware entry")
+                            .c_str());
+        throw type::CommonError::InsufficientPermission();
+    }
+
     resolveEntry();
 }
 

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -335,7 +335,7 @@ void Manager::deleteAll()
         // Continue other entries to delete if failed to delete one entry
         try
         {
-            entry->delete_();
+            entry->resolveEntry();
         }
         catch (std::exception& e)
         {


### PR DESCRIPTION
- We should not allow the user to delete the system isolated hw entry
  because that might be created by the system due to some hardware error.

  - If we are allowed to clear that entry then, the system might hit
    the same error until the hardware is replaced.

- So, restricted the user to delete the system isolated hw entry
  in the patch.

- Note, The openpower-hw-isolation still allows the system isolated
  hardware entries to clear if the user tried through "DeleteAll".

Tested:

- Verified by clearing the system isolated hardware entry through D-Bus.

```
> guard -l
ID       | ERROR    |  Type  | Path
00000001 | 50000425 | fatal | physical:sys-0/node-0/dimm-0

> busctl call org.open_power.HardwareIsolation /xyz/openbmc_project/ \
              hardware_isolation/entry/1 xyz.openbmc_project.Object.Delete Delete
Call failed: Insufficient permission to perform operation
```

Gerrit DBus changes for the same: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/52161