### PR TITLE
event: Create an event if the core is deallocated at the runtime

### DIFF
--- a/include/common/isolatable_hardwares.hpp
+++ b/include/common/isolatable_hardwares.hpp
@@ -320,21 +320,6 @@ class IsolatableHWs
         getParentFruPhalDevTreeTgt(struct pdbg_target* devTreeTgt);
 
     /**
-     * @brief Used to get child inventory path by using parent
-     *        parent inventory path with specific interface
-     *
-     * @param[in] parentObjPath - The parent object path to get subtrees
-     * @param[in] interfaceName - The child interface name
-     *
-     * @return The list of child inventory path on success
-     *         Empty optional on failure
-     */
-    std::optional<std::vector<sdbusplus::message::object_path>>
-        getChildsInventoryPath(
-            const sdbusplus::message::object_path& parentObjPath,
-            const std::string& interfaceName);
-
-    /**
      * @brief Used to get the FRU inventory path by using the given
      *        FRU details (location code and instance id)
      *

--- a/include/common/utils.hpp
+++ b/include/common/utils.hpp
@@ -209,5 +209,21 @@ std::optional<sdbusplus::message::object_path>
 std::optional<type::InstanceId>
     getInstanceId(const std::string& objPathSegment);
 
+/**
+ * @brief Used to get child inventory path by using parent
+ *        parent inventory path with specific interface
+ *
+ * @param[in] bus - Bus to attach to.
+ * @param[in] parentObjPath - The parent object path to get subtrees
+ * @param[in] interfaceName - The child interface name
+ *
+ * @return The list of child inventory path on success
+ *         Empty optional on failure
+ */
+std::optional<std::vector<sdbusplus::message::object_path>>
+    getChildsInventoryPath(sdbusplus::bus::bus& bus,
+                           const sdbusplus::message::object_path& parentObjPath,
+                           const std::string& interfaceName);
+
 } // namespace utils
 } // namespace hw_isolation

--- a/include/hw_isolation_event/hw_status_manager.hpp
+++ b/include/hw_isolation_event/hw_status_manager.hpp
@@ -42,15 +42,11 @@ class Manager
     Manager(sdbusplus::bus::bus& bus, record::Manager& hwIsolationRecordMgr);
 
     /**
-     * @brief Used to create hardware status event for all hardware.
+     * @brief API used to restore the hardware status event.
      *
      * @return NULL
-     *
-     * @note This function will skip to create
-     *       the hardware status event if any failures while
-     *       processing all hardware.
      */
-    void restoreHardwaresStatusEvent();
+    void restore();
 
   private:
     /**
@@ -177,6 +173,28 @@ class Manager
      * @return NULL
      */
     void watchOperationalStatusChange();
+
+    /**
+     * @brief API used to know whether OS is running or not.
+     *
+     * @return true if OS is running else false.
+     */
+    bool isOSRunning();
+
+    /**
+     * @brief Used to create hardware status event for all hardware.
+     *
+     * @param[in] osRunning - used to decide whether wants to restore
+     *                        cores events if the cores are deallocated
+     *                        at the runtime. By default, it won't restore.
+     *
+     * @return NULL
+     *
+     * @note This function will skip to create
+     *       the hardware status event if any failures while
+     *       processing all hardware.
+     */
+    void restoreHardwaresStatusEvent(bool osRunning = false);
 };
 
 } // namespace hw_status

--- a/include/hw_isolation_event/hw_status_manager.hpp
+++ b/include/hw_isolation_event/hw_status_manager.hpp
@@ -92,6 +92,13 @@ class Manager
         _dbusSignalWatcher;
 
     /**
+     * @brief The list of D-Bus object to watch OperationalStatus
+     */
+    std::unordered_map<std::string,
+                       std::unique_ptr<sdbusplus::bus::match::match>>
+        _watcherOnOperationalStatus;
+
+    /**
      * @brief Create the hardware status event dbus object
      *
      * @param[in] eventSeverity - the severity of the event.
@@ -142,6 +149,34 @@ class Manager
      * @return NULL
      */
     void onBootProgressChange(sdbusplus::message::message& message);
+
+    /**
+     * @brief API used to clear the existing events for the given hardware
+     *        inventory path
+     *
+     * @param[in] hwInventoryPath - The hardware inventory path to clear.
+     *
+     * @return NULL
+     */
+    void clearHwStatusEventIfexists(const std::string& hwInventoryPath);
+
+    /**
+     * @brief Used to create event on the object if that object is not
+     *        functional
+     *
+     * @param[in] message - The D-Bus signal message
+     *
+     * @return NULL
+     */
+    void onOperationalStatusChange(sdbusplus::message::message& message);
+
+    /**
+     * @brief Used to create the D-Bus signal watcher on the OperationalStatus
+     *        interface for the defined inventory item interface.
+     *
+     * @return NULL
+     */
+    void watchOperationalStatusChange();
 };
 
 } // namespace hw_status

--- a/src/hardware_isolation_main.cpp
+++ b/src/hardware_isolation_main.cpp
@@ -38,7 +38,7 @@ int main()
         hw_isolation::event::hw_status::Manager hwStatusMgr(bus, record_mgr);
 
         // Restore the hardware status event from their persisted location.
-        hwStatusMgr.restoreHardwaresStatusEvent();
+        hwStatusMgr.restore();
 
         // The below statement should be last to enter this app into the loop
         // to process D-Bus services.

--- a/src/hw_isolation_event/hw_status_manager.cpp
+++ b/src/hw_isolation_event/hw_status_manager.cpp
@@ -261,9 +261,10 @@ void Manager::restoreHardwaresStatusEvent(bool osRunning)
                                         "OperationalStatus",
                                         "Functional");
 
-                                if (hwasState.deconfiguredByEid ==
-                                    openpower_hw_status::DeconfiguredByReason::
-                                        CONFIGURED_BY_RESOURCE_RECOVERY)
+                                if (functionalInInventory &&
+                                    (hwasState.deconfiguredByEid ==
+                                     openpower_hw_status::DeconfiguredByReason::
+                                         CONFIGURED_BY_RESOURCE_RECOVERY))
                                 {
                                     /**
                                      * Event is required since the hardware is


### PR DESCRIPTION
- In the OpenPOWER based system, the Core can be deallocated at the runtime
  by creating the hardware isolation record.

- If the Core is deallocated then, we need to communicate this information
  to the end-user whenever the user tried to get a core state.

- So, The openpower-hw-isolation application will start watcher once the host
  reached to runtime (OSRunning) to monitor the Functional property value
  change for all present cores in the inventory.

- Once the core is deallocated in the host side, the host will send the PLDM
  sensor event to the BMC that will update in the core inventory Functional
  property, now the watcher will wake and look for the respective core
  hardware isolation record and create an event that will be translated into
  the Redfish Status.Condition property when the user requesting to get
  the core state.

- Note:

  - The hardware isolation record will be created before deallocation
    based on the error.

  - So, the host will decide whether it can deallocate or not.

    - The event won't be created if the core is not deallocated as like
      standby hardware isolation record creation.

Tested:

- Verified by deallocating the core at the runtime.

  - Simulated the partition load at the PHYP console.

```
> htxcmdline -run -mdt mdt.all
```

  - Injected the error at the BMC console

```
> putscom pu.c 20028000 0000020000000000 -n0 -p00 -c0
```

  - Verified the hardware isolation record.

```
> guard -l

ID       | ERROR    |  Type  | Path
00000001 | 89001d1a | predictive | physical:sys-0/node-0/proc-0/eq-0/fc-0/core-0
```

  - Verified the error log.

```
peltool -l
{
    "0x89001D1A": {
        "SRC":                  "BC13E504",
        "PLID":                 "0x89001D1A",
        "CreatorID":            "Hostboot",
        "Subsystem":            "Processor Unit (CPU)",
        "Commit Time":          "03/25/2022 10:51:39",
        "Sev":                  "Predictive Error",
        "CompID":               "0xE500"
    }
}
```

  - Verified the core state at the PHYP console.

```
> hvgardinject gi

PacaId hwProcId ProcessorState OwningPartition      GardState
   0        0      GardedOff          FFFF          ProcStopped --> deallocated
   1        0      GardedOff          FFFF          ProcStopped
   2        0      GardedOff          FFFF          ProcStopped
   3        0      GardedOff          FFFF          ProcStopped
   4        0      GardedOff          FFFF          ProcStopped
   5        0      GardedOff          FFFF          ProcStopped
   6        0      GardedOff          FFFF          ProcStopped
   7        0      GardedOff          FFFF          ProcStopped
```

  - Verified the core state in the Redfish.

```
> GET https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core0

{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core0",
  "@odata.type": "#Processor.v1_12_0.Processor",
  "Enabled": false,
  "Id": "core0",
  "Name": "core0",
  "Status": {
    "Conditions": [
      {
        "LogEntry": {
          "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/1238"
        },
        "Message": "The reason for the resource isolation: Predictive",
        "MessageArgs": [
          "Predictive"
        ],
        "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
        "Severity": "Warning",
        "Timestamp": "2022-03-25T10:51:43+00:00"
      }
    ],
    "Health": "Critical",
    "State": "Disabled"
  }
}
```