### PR TITLE
record: Use timer event source instead of sleep call

### DIFF
--- a/src/hardware_isolation_main.cpp
+++ b/src/hardware_isolation_main.cpp
@@ -30,7 +30,7 @@ int main()
                                                        HW_ISOLATION_OBJPATH);
 
         hw_isolation::record::Manager record_mgr(bus, HW_ISOLATION_OBJPATH,
-                                                 event.get());
+                                                 event);
 
         // Restore the isolated hardwares from their persisted location.
         record_mgr.restore();


### PR DESCRIPTION
- Currently, the openpower-hw-isolation application using the sleep
  call to solve the atomicity on hardware isolation record partition
  file if the file is updated by the host application.

- The openpower-hw-isolation application acting as a D-Bus service
  daemon to process the implemented D-Bus request but due to the sleep
  call the openpower-hw-isolation application halted so, it was not able
  to process the D-Bus request until the sleep call returns.

- So, fixing this by using the timer event source i.e, the timer object
  will be created whenever the inotify event is received, once the timer
  is expired, remove timer and process hardware isolation records from
  the partition file.

Tested:

- Verified by sending more than one request at the same time.