### PR TITLE
service: Don't launch the application with "env"

### DIFF
--- a/service_files/org.open_power.HardwareIsolation.service
+++ b/service_files/org.open_power.HardwareIsolation.service
@@ -9,7 +9,7 @@ After=pldmd.service
 After=openpower-update-bios-attr-table.service
 
 [Service]
-ExecStart=/usr/bin/env openpower-hw-isolation
+ExecStart=/usr/bin/openpower-hw-isolation
 SyslogIdentifier=openpower-hw-isolation
 Restart=always
 Type=dbus


### PR DESCRIPTION
- In the OpenBMC project there is an anti-pattern that says we should not
  launch the application with the "env".

- Refer to the below link to get more details
  https://github.com/openbmc/docs/blob/master/anti-patterns.md#use-of-usrbinenv-in-systemd-service-files