### PR TITLE
service: Start HardwareIsolation before Reinit PHAL DEVTREE

### DIFF
--- a/service_files/org.open_power.HardwareIsolation.service
+++ b/service_files/org.open_power.HardwareIsolation.service
@@ -7,6 +7,7 @@ After=mapper-wait@-xyz-openbmc_project-state-host0.service
 Wants=pldmd.service
 After=pldmd.service
 After=openpower-update-bios-attr-table.service
+Before=phal-reinit-devtree.service
 
 [Service]
 ExecStart=/usr/bin/openpower-hw-isolation


### PR DESCRIPTION
It fixes [SW549944](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW549944) - Created an MFT and it is in the review for the approval.

- The "phal-reinit-devtree" service will be called as part of the
  host cold boot path to reinit the PHAL device tree with read-only
  version device tree and preserve attributes if any into read-write
  version device tree.

- The HardwareIsolation service will be called as part of the BMC
  boot path.

- Recently, we noticed that the host trying to boot before the BMC
  raches to standby (aka Ready) state i.e the BMC and Host trying
  to boot parallel due to the external or internal request and that
  is not expected but, we cannot control that on a certain path
  (for example, in-band code update path).

- So, whenever the Host trying to boot before the BMC reaches Ready
  state, we are hitting the race condition between the HardwareIsolation
  and phal-reinit-devtree services when trying to access read-write
  version device tree at the same time and the HardwareIsolation is
  crashed.

  - This crash is happening in the specific window (restore path)
    i.e when the HardwareIsolation starts it will restore the hardware
    isolation reason for the DIMM and Core by using the HWAS_STATE
    attributes that exist in the PHAL device tree, and meanwhile the PHAL
    device tree is reinited.

- Currently, we don't have any locking mechanism over the read-write
  version device tree to use by the multiple application so safer side
  enforcing to start the HardwareIsolation service before
  phal-reinit-devtree service to fix the crash while restoring
  the hardware isolation reason for the DIMM and Core.

Traces:

- Systemd service traces

```
May 04 08:32:31 bmc systemd[1]: Starting OpenPOWER Host HardwareIsolation...
...
May 04 08:32:31 bmc systemd[1]: Starting Reinit POWER CEC system device tree...
...
May 04 08:32:33 bmc systemd[1]: Finished Reinit POWER CEC system device tree.
...
May 04 08:32:35 bmc systemd[1]: org.open_power.HardwareIsolation.service: Failed with result 'core-dump'.
May 04 08:32:35 bmc systemd[1]: Failed to start OpenPOWER Host HardwareIsolation.
```

- Core dump traces

```
>0  strlen () at ../sysdeps/arm/armv6t2/strlen.S:126
126 ../sysdeps/arm/armv6t2/strlen.S: No such file or directory.
>0  strlen () at ../sysdeps/arm/armv6t2/strlen.S:126
>1  0x76555dc8 in _fdt_string_eq (len=15, s=<optimized out>, stroffset=<optimized out>, fdt=0x76310000) at ../../git/libfdt/fdt_ro.c:88
>2  fdt_get_property_namelen (fdt=fdt@entry=0x76310000, offset=191356, offset@entry=2127296008, name=0x7ecbf65c "ATTR_HWAS_STATE",
    name@entry=0x1e898 <error: Cannot access memory at address 0x1e898>, namelen=15, lenp=lenp@entry=0x7ecbf608) at ../../git/libfdt/fdt_ro.c:306
>3  0x76555e60 in fdt_getprop_namelen (fdt=fdt@entry=0x76310000, nodeoffset=nodeoffset@entry=2127296008,
    name=name@entry=0x1e898 <error: Cannot access memory at address 0x1e898>, namelen=<optimized out>, lenp=lenp@entry=0x7ecbf608)
    at ../../git/libfdt/fdt_ro.c:329
>4  0x76555eec in fdt_getprop (fdt=0x76310000, nodeoffset=2127296008, name=0x1e898 <error: Cannot access memory at address 0x1e898>,
    name@entry=0x7ecbf65c "ATTR_HWAS_STATE", lenp=0x7ecbf608, lenp@entry=0x7ecbf600) at ../../git/libfdt/fdt_ro.c:352
>5  0x76db4e2c in _target_property (target=<optimized out>, target=<optimized out>, size=<optimized out>, name=<optimized out>) at ../git/libpdbg/device.c:326
>6  pdbg_target_property (target=0x1451ff0, name=0x7ecbf65c "ATTR_HWAS_STATE", size=0x7ecbf620) at ../git/libpdbg/device.c:367
>7  0x76db5bc4 in pdbg_target_get_attribute_packed (target=<optimized out>, name=<optimized out>,
    spec=0x547134 <_ZN6dtAttr5fapi2L20ATTR_HWAS_STATE_SpecE.lto_priv.1+8> "41", count=1, val=0x7ecbf6bc) at ../git/libpdbg/device.c:950
>8  0x76f1f13c in fapi2::getProperty (target=0x1451ff0, attrId=..., val=0x7ecbf6bc, eleCount=1, attrSize=5, attrTypeName="struct", attrSpec="41")
    at /usr/include/c++/11.2.0/bits/basic_string.h:2319
>9  0x00511d74 in auto hw_isolation::event::hw_status::Manager::restoreHardwaresStatusEvent(bool)::{lambda(auto:1 const&)>1}::operator()<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const [clone .lto_priv.0] () at /usr/include/c++/11.2.0/bits/basic_string.h:533
>10 0x004f74f8 in std::for_each<__gnu_cxx::__normal_iterator<std::__cxx11::basic_string<char>*, std::vector<std::__cxx11::basic_string<char> > >, hw_isolation::event::hw_status::Manager::restoreHardwaresStatusEvent(bool)::<lambda(const auto:44&)> > (__f=..., __last=..., __first="fc")
    at /usr/include/c++/11.2.0/bits/stl_algo.h:3819
>11 hw_isolation::event::hw_status::Manager::restoreHardwaresStatusEvent (
    osRunning=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>,
    this=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at ../git/src/hw_isolation_event/hw_status_manager.cpp:177
>12 hw_isolation::event::hw_status::Manager::restore (this=0x7ecbf950) at ../git/src/hw_isolation_event/hw_status_manager.cpp:774
>13 main () at ../git/src/hardware_isolation_main.cpp:41
```

Tested:
 - Verified the BMC and Host boot path to make sure no crash
   for the hardware isolation application.

```
May 10 11:22:29 bmc systemd[1]: Starting OpenPOWER Host HardwareIsolation...
May 10 11:22:37 bmc systemd[1]: Started OpenPOWER Host HardwareIsolation.
May 10 11:22:37 bmc systemd[1]: Starting Reinit POWER CEC system device tree...
May 10 11:22:37 bmc openpower-proc-control[2516]: reinitDevtree: started
May 10 11:22:37 bmc openpower-proc-control[2516]: reinitDevtree: completed successfully
May 10 11:22:37 bmc systemd[1]: phal-reinit-devtree.service: Deactivated successfully.
May 10 11:22:37 bmc systemd[1]: Finished Reinit POWER CEC system device tree.
```