### PR TITLE
record : during restore do not check if error log objects exists

### DIFF
--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -503,7 +503,7 @@ void Manager::createEntryForRecord(const openpower_guard::GuardRecord& record,
 
         auto bmcErrorLogPath = utils::getBMCLogPath(_bus, record.elogId);
 
-        if (!bmcErrorLogPath.has_value())
+        if (!isRestorePath && !bmcErrorLogPath.has_value())
         {
             log<level::ERR>(
                 fmt::format(


### PR DESCRIPTION
At present during restore Hw-isolation is not listing the guarded  entries if the corresponding error log object is not found.
During PEL deletion it deletes the error log objects but does not delete the associated guard record.
Now modified to not to check for error log object during restore path as the error log object might have been deleted during PEL deletion.

Tested:
[devenrao]$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries

{
  "@odata.id":
"/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of System Hardware Isolation Entries",
  "Members": [
    {
      "@odata.id":
"/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI":
"/redfish/v1/Systems/system/LogServices/EventLog/Entries/2401/attachment",
      "Created": "2022-06-24T09:49:29+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id":
"/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core0"
        }
      },
      "Message": "core0",
      "Name": "Hardware Isolation Entry",
      "Severity": "Warning"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Hardware Isolation Entries"
}

curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}//redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1
Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I6913533b722836e0a52a54de23932db37a7b01b8