### PR TITLE
record: fix guard record not created during checkstop

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -143,8 +143,18 @@ void setEnabledProperty(sdbusplus::bus::bus& bus,
         {
             return;
         }
-        throw sdbusplus::exception::SdBusError(
-            const_cast<sd_bus_error*>(e.get_error()), "HW-Isolation");
+        // TODO:https://github.com/ibm-openbmc/openpower-hw-isolation/issues/39
+        // During "core" checkstop PLDM will be blocked on the DMA transfer of
+        // the dump data and might not honor enabling D-Bus property of core
+        // D-Bus object during hw-isolation entry creation. PLDM hosts
+        // the "core" D-Bus object and request need to be sent to PLDM for
+        // property change request. For now, ignoring the exception thrown, the
+        // property will be enabled again during refresh.
+        // throw sdbusplus::exception::SdBusError(
+        //    const_cast<sd_bus_error*>(e.get_error()), "HW-Isolation");
+        log<level::ERR>(
+            fmt::format("Exception [{}], failed to get service name", e.what())
+                .c_str());
     }
 
     try
@@ -195,8 +205,19 @@ void setEnabledProperty(sdbusplus::bus::bus& bus,
         {
             return;
         }
-        throw sdbusplus::exception::SdBusError(
-            const_cast<sd_bus_error*>(e.get_error()), "HW-Isolation");
+        // TODO:https://github.com/ibm-openbmc/openpower-hw-isolation/issues/39
+        // During "core" checkstop PLDM will be blocked on the DMA transfer of
+        // the dump data and might not honor enabling D-Bus property of core
+        // D-Bus object during hw-isolation entry creation. PLDM hosts
+        // the "core" D-Bus object and request need to be sent to PLDM for
+        // property change request. For now, ignoring the exception thrown, the
+        // property will be enabled again during refresh.
+        // throw sdbusplus::exception::SdBusError(
+        //    const_cast<sd_bus_error*>(e.get_error()), "HW-Isolation");
+        log<level::ERR>(
+            fmt::format("Exception [{}], failed to set enable D-Bus property",
+                        e.what())
+                .c_str());
     }
 }
 

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -652,6 +652,8 @@ void Manager::updateEntryForRecord(const openpower_guard::GuardRecord& record,
         updated = true;
     }
 
+    utils::setEnabledProperty(_bus, *isolatedHwInventoryPath, false);
+
     if (updated)
     {
         // Existing entry might be overwritten if that's meets certain


### PR DESCRIPTION
When an error is injected onto a core at runtime system checkstops guards the core and creates an hw-isolation entry

hw-isolation as part of creating isolation entry sets the enabled property of the core D-Bus object hosted by PLDM.

In a rare window, PLDM hangs during checkstop and recovers back. If any request comes to enable the D-Bus property of the core D-Bus object hosted by PLDM in this window the same will not be honored.

As D-Bus setProperty method fails current implementation creates the isolation entry but not the guard record.

The customer would fail to see a guard record due to checkstop and in absence of a guard record, the subsequent boots would try to boot the bad core (which should have guarded in the first place)

In the future when core D-Bus objects will be hosted by EntityManager by then we will not have any issues.

It is difficult to reproduce the issue, so tested good path and captured results below.

Tested
root@p10bmc:/tmp# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x50001890 | fatal           |
physical:sys-0/node-0/proc-0/eq-6/fc-1/core-1

Signed-off-by: Marri  Rao <devenrao@in.ibm.com>
Change-Id: I0eb710f4213a9c58136da5bfa0d5966744d0af21