### PR TITLE
1050 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # openpower-hw-isolation
-In OpenPOWER based system, a user or application can isolate hardware and the respective
-isolated hardware will be ignored to init during the next boot of the host.
+
+In OpenPOWER based system, a user or application can isolate hardware and the
+respective isolated hardware will be ignored to init during the next boot of the
+host.
 
 **Note:**
-- The system must be in a power-off state when a user wants to isolate or deisolate hardware.
-- The isolated hardware details will be considered only in the next boot of the host to isolate.
+
+- The system must be in a power-off state when a user wants to isolate or
+  deisolate hardware.
+- The isolated hardware details will be considered only in the next boot of the
+  host to isolate.
 
 ### To build
+
 ```
 meson builddir
 ninja -C builddir

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -52,7 +52,14 @@ std::string getDBusServiceName(sdbusplus::bus::bus& bus,
 
     // In OpenBMC, the object path will be hosted by a single service
     // i.e more than one service cannot host the same object path.
-    if (servicesName.size() > 1)
+    // Note that for legacy reasons, phosphor-state-manager registers two
+    // service names, xyz.openbmc_project.State.Host and
+    // xyz.openbmc_project.State.Host0. This was to support multi-host
+    // designs but also support legacy users. This is the one exception
+    // to the "more than one service" rule
+    if ((servicesName.size() > 1) &&
+        (servicesName[0].first.find("xyz.openbmc_project.State.Host") ==
+         std::string::npos))
     {
         std::string serviceNameList{""};
 


### PR DESCRIPTION
Upstream added support for multi-host designs. That is, there could be
multiple host instances supported by one BMC. To do that, they instanced
the xyz.openbmc_project.State.Host service (so there is now a 0,1,2,...
added to the end of the service name.

To support backwards compatibility they have the host instance 0 service
also host the old xyz.openbmc_project.State.Host service name. This
means that one application is hosting both the
xyz.openbmc_project.State.Host and xyz.openbmc_project.State.Host0
service name. Either will work, but code needs to handle getting back 2
service names.

If IBM some day supports this multiple instance concept, then this code
will need a refactor. For now, since IBM only supports the one host
instance, put an exception in the rules to allow for the multiple
service names.

Tested:
- Built 1050 image with this change and verified service no longer fails