### PR TITLE
faultlog : add hardware isolation errorlog data to NAG json

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,3 +113,5 @@ configure_file(
     install_dir: systemd_system_unit_dir,
     output: '@PLAINNAME@'
     )
+
+subdir('src')

--- a/src/faultlog/fault_log_main.cpp
+++ b/src/faultlog/fault_log_main.cpp
@@ -1,0 +1,31 @@
+#include <faultlog_records.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+#include <iostream>
+#include <vector>
+
+using namespace openpower::faultlog;
+using ::nlohmann::json;
+
+int main(int /*arg*/, char** /*argv*/)
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+
+        nlohmann::json faultLogJson = json::array();
+        std::vector<int> processedEid;
+
+        // add hardware isolation records to json file
+        FaultLogRecords::populate(bus, faultLogJson, processedEid);
+        std::cout << "Nag data is " << std::endl;
+        std::cout << faultLogJson.dump(2) << std::endl;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    return 0;
+}

--- a/src/faultlog/fault_log_main.cpp
+++ b/src/faultlog/fault_log_main.cpp
@@ -1,3 +1,4 @@
+#include <faultlog_policy.hpp>
 #include <faultlog_records.hpp>
 #include <nlohmann/json.hpp>
 #include <sdbusplus/bus.hpp>
@@ -19,6 +20,7 @@ int main(int /*arg*/, char** /*argv*/)
 
         // add hardware isolation records to json file
         FaultLogRecords::populate(bus, faultLogJson, processedEid);
+        FaultLogPolicy::populate(bus, faultLogJson);
         std::cout << "Nag data is " << std::endl;
         std::cout << faultLogJson.dump(2) << std::endl;
     }

--- a/src/faultlog/faultlog_policy.cpp
+++ b/src/faultlog/faultlog_policy.cpp
@@ -1,0 +1,70 @@
+#include <fmt/format.h>
+
+#include <faultlog_policy.hpp>
+#include <phosphor-logging/log.hpp>
+#include <util.hpp>
+
+namespace openpower::faultlog
+{
+using ::nlohmann::json;
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+
+/**
+ * @class FaultLogPolicy
+ *
+ * Capture hardware isolation policy and FCO value in NAG json file
+ */
+int FaultLogPolicy::populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson)
+{
+    log<level::INFO>("FaultLogPolicy::populate()");
+    try
+    {
+        json jsonPolicyVal = json::object();
+        // FCO_VALUE
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.BIOSConfigManager",
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "GetAttribute");
+        method.append("hb_field_core_override");
+
+        std::tuple<std::string, std::variant<int64_t, std::string>,
+                   std::variant<int64_t, std::string>>
+            attrVal;
+        auto result = bus.call(method);
+        result.read(std::get<0>(attrVal), std::get<1>(attrVal),
+                    std::get<2>(attrVal));
+
+        std::variant<int64_t, std::string> attr = std::get<1>(attrVal);
+        uint32_t fcoVal = 0;
+        if (auto pVal = std::get_if<int64_t>(&attr))
+        {
+            fcoVal = *pVal;
+        }
+        jsonPolicyVal["FCO_VALUE"] = fcoVal;
+
+        // master guard enabled or not
+        bool enabled = readProperty<bool>(
+            bus, "xyz.openbmc_project.Settings",
+            "/xyz/openbmc_project/hardware_isolation/allow_hw_isolation",
+            "xyz.openbmc_project.Object.Enable", "Enabled");
+        jsonPolicyVal["MASTER"] = enabled;
+
+        // predictive guard enabled or not
+        // at present not present in BMC will leave it as true for now
+        jsonPolicyVal["PREDICTIVE"] = true;
+
+        json jsonPolicy = json::object();
+        jsonPolicy["POLICY"] = std::move(jsonPolicyVal);
+        nagJson.push_back(std::move(jsonPolicy));
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to add policy details to NAG ({})", ex.what())
+                .c_str());
+    }
+
+    return 0;
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/faultlog_policy.hpp
+++ b/src/faultlog/faultlog_policy.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace openpower::faultlog
+{
+/**
+ * @class FaultLogPolicy
+ *
+ * Capture faultlog policy and FCO value
+ */
+class FaultLogPolicy
+{
+  private:
+    FaultLogPolicy() = delete;
+    FaultLogPolicy(const FaultLogPolicy&) = delete;
+    FaultLogPolicy& operator=(const FaultLogPolicy&) = delete;
+    FaultLogPolicy(FaultLogPolicy&&) = delete;
+    FaultLogPolicy& operator=(FaultLogPolicy&&) = delete;
+    virtual ~FaultLogPolicy() = default;
+
+  public:
+    /** @brief Populate hardware isolation policy and FCO value
+     *
+     *  @param[in] bus - D-Bus to attach to
+     *  @param[in] json - mag JSON file
+     *  @return 1 on failure and 0 on success
+     */
+    static int populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/faultlog_records.cpp
+++ b/src/faultlog/faultlog_records.cpp
@@ -1,0 +1,114 @@
+#include <fmt/format.h>
+
+#include <faultlog_records.hpp>
+#include <phosphor-logging/log.hpp>
+#include <servicable_records.hpp>
+
+#include <vector>
+
+namespace openpower::faultlog
+{
+using ::nlohmann::json;
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+
+using AssociationTyple = std::tuple<std::string, std::string, std::string>;
+using AssociationsValType = std::vector<AssociationTyple>;
+
+using PropertyValue =
+    std::variant<std::string, bool, uint8_t, int16_t, uint16_t, int32_t,
+                 uint32_t, int64_t, uint64_t, double, AssociationsValType>;
+
+using Properties = std::map<std::string, PropertyValue>;
+
+using Interfaces = std::map<std::string, Properties>;
+
+/**
+ * @class FaultLogRecords
+ *
+ * Capture all hardware isolation records into the JSON file/
+ */
+int FaultLogRecords::populate(sdbusplus::bus::bus& bus, json& nagJson,
+                              std::vector<int>& /*processedEid*/)
+{
+    log<level::INFO>("FaultLogRecords::populate()");
+    try
+    {
+
+        using Objects = std::map<sdbusplus::message::object_path, Interfaces>;
+
+        Objects objects;
+        auto method = bus.new_method_call(
+            "org.open_power.HardwareIsolation",
+            "/xyz/openbmc_project/hardware_isolation",
+            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+        auto reply = bus.call(method);
+        reply.read(objects);
+
+        for (auto& iter : objects)
+        {
+            std::string prefix = {
+                "/xyz/openbmc_project/hardware_isolation/entry/"};
+            // could be status object
+            std::string object = std::move(std::string(iter.first));
+            if (object.find(prefix) != 0)
+            {
+                continue;
+            }
+            json jsonErrorLog = json::object();
+            log<level::INFO>(
+                fmt::format("FaultLogRecords::parse({})", iter.first.str)
+                    .c_str());
+            for (auto& interface : iter.second)
+            {
+                if (interface.first == "xyz.openbmc_project.Association."
+                                       "Definitions")
+                {
+                    for (auto& property : interface.second)
+                    {
+                        if (property.first == "Associations")
+                        {
+                            const AssociationsValType* associations =
+                                std::get_if<AssociationsValType>(
+                                    &property.second);
+                            if (associations == nullptr)
+                            {
+                                log<level::ERR>("Failed to get associations");
+                                continue;
+                            }
+                            for (auto& assoc : *associations)
+                            {
+                                if (std::get<0>(assoc) ==
+                                    "isolated_hw_errorlog")
+                                {
+                                    sdbusplus::message::object_path errPath =
+                                        std::get<2>(assoc);
+                                    log<level::INFO>(
+                                        fmt::format("isolated_hw_errorlog ({})",
+                                                    errPath.str)
+                                            .c_str());
+                                    ServicableRecords::populate(bus, errPath,
+                                                                jsonErrorLog);
+                                }
+                            }
+                        }
+                    }
+                } // else if
+            }     // for interfaces
+            json jsonEventData = json::object();
+            jsonEventData["CEC_ERROR_LOG"] = std::move(jsonErrorLog);
+            json jsonServiceEvent = json::object();
+            jsonServiceEvent["SERVICABLE_EVENT"] = std::move(jsonEventData);
+            nagJson.push_back(std::move(jsonServiceEvent));
+        } // for objects
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to add hardware isolation records ({})",
+                        ex.what())
+                .c_str());
+    }
+    return 0;
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/faultlog_records.hpp
+++ b/src/faultlog/faultlog_records.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace openpower::faultlog
+{
+/**
+ * @class FaultLogRecords
+ *
+ * Capture all hardware isolation records to the NAG json file
+ */
+class FaultLogRecords
+{
+  private:
+    FaultLogRecords() = delete;
+    FaultLogRecords(const FaultLogRecords&) = delete;
+    FaultLogRecords& operator=(const FaultLogRecords&) = delete;
+    FaultLogRecords(FaultLogRecords&&) = delete;
+    FaultLogRecords& operator=(FaultLogRecords&&) = delete;
+    virtual ~FaultLogRecords() = default;
+
+  public:
+    /** @brief Parse through hardware isolation records and fill NAG json
+     *
+     *  @param[in] bus - D-Bus to attach to
+     *  @param[in] json - mag JSON file
+     *  @param[in] processedEid - Update with processed errorlog objects
+     *  @return 1 on failure and 0 on success
+     */
+    static int populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson,
+                        std::vector<int>& processedEid);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -31,7 +31,8 @@ systemd_dep = dependency('systemd')
 faultlog_sources = [ 
         'fault_log_main.cpp',
         'faultlog_records.cpp',
-        'servicable_records.cpp'
+        'servicable_records.cpp',
+        'faultlog_policy.cpp'
         ]
 
 faultlog_dependencies = [ 

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -1,0 +1,49 @@
+cpp = meson.get_compiler('cpp')
+
+sdbusplus_dep = dependency(
+    'sdbusplus',
+    fallback: ['sdbusplus', 'sdbusplus_dep'],
+)
+
+phosphor_dbus_interfaces_dep = dependency(
+    'phosphor-dbus-interfaces',
+    fallback: [
+        'phosphor-dbus-interfaces',
+        'phosphor_dbus_interfaces_dep'
+    ],  
+)
+
+phosphor_logging_dep = dependency(
+    'phosphor-logging',
+    fallback: ['phosphor-logging', 'phosphor_logging_dep'],
+)
+
+if cpp.has_header('nlohmann/json.hpp')
+    nlohmann_json = declare_dependency()
+else
+    nlohmann_json_proj = subproject('nlohmann', required: true)
+    nlohmann_json = nlohmann_json_proj.get_variable('nlohmann_json_dep')
+    nlohmann_json = nlohmann_json.as_system('system')
+endif
+
+systemd_dep = dependency('systemd')
+
+faultlog_sources = [ 
+        'fault_log_main.cpp',
+        'faultlog_records.cpp',
+        'servicable_records.cpp'
+        ]
+
+faultlog_dependencies = [ 
+        format,
+        phosphor_dbus_interfaces,
+        phosphor_logging,
+        sdbusplus,
+        nlohmann_json
+    ]   
+executable('faultlog',
+           faultlog_sources,
+           dependencies: faultlog_dependencies,
+           install : true
+          )
+

--- a/src/faultlog/servicable_records.cpp
+++ b/src/faultlog/servicable_records.cpp
@@ -1,0 +1,34 @@
+#include <fmt/format.h>
+
+#include <phosphor-logging/log.hpp>
+#include <servicable_records.hpp>
+
+namespace openpower::faultlog
+{
+using ::nlohmann::json;
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+
+void ServicableRecords::populate(sdbusplus::bus::bus& bus,
+                                 sdbusplus::message::object_path& errorLog,
+                                 json& jsonServEvent)
+{
+    log<level::INFO>(
+        fmt::format("parseErrorlogObjectPath errorlog ({})", errorLog.str)
+            .c_str());
+    std::string pel;
+    auto method = bus.new_method_call(
+        "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+        "org.open_power.Logging.PEL", "GetPELJSON");
+    method.append(static_cast<uint32_t>(std::stoi(errorLog.filename())));
+    auto resp = bus.call(method);
+    resp.read(pel);
+    json pelJson = std::move(json::parse(pel));
+
+    jsonServEvent["ERR_PLID"] = pelJson["Private Header"]["Platform Log Id"];
+    jsonServEvent["Callout Section"] =
+        pelJson["Primary SRC"]["Callout Section"];
+    jsonServEvent["SRC"] = pelJson["Primary SRC"]["Reference Code"];
+    jsonServEvent["DATE_TIME"] = pelJson["Private Header"]["Created at"];
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/servicable_records.hpp
+++ b/src/faultlog/servicable_records.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace openpower::faultlog
+{
+/**
+ * @class ServicableRecords
+ *
+ * Capture hardware isolation servicable records in JSON file
+ */
+class ServicableRecords
+{
+  private:
+    ServicableRecords() = delete;
+    ServicableRecords(const ServicableRecords&) = delete;
+    ServicableRecords& operator=(const ServicableRecords&) = delete;
+    ServicableRecords(ServicableRecords&&) = delete;
+    ServicableRecords& operator=(ServicableRecords&&) = delete;
+    virtual ~ServicableRecords() = default;
+
+  public:
+    /** @brief Parse through the error log object and update the NAG json
+     *
+     *  @param[in] bus - D-Bus to attach to
+     *  @param[in] errorLog - D-Bus error log object to process data
+     *  @param[in] jsonServEvent - Update JSON servicable event
+     */
+    static void populate(sdbusplus::bus::bus& bus,
+                         sdbusplus::message::object_path& errorLog,
+                         nlohmann::json& jsonServEvent);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/subprojects/phosphor-dbus-interfaces.wrap
+++ b/src/faultlog/subprojects/phosphor-dbus-interfaces.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/openbmc/phosphor-dbus-interfaces.git
+revision = HEAD

--- a/src/faultlog/subprojects/phosphor-logging.wrap
+++ b/src/faultlog/subprojects/phosphor-logging.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/openbmc/phosphor-logging.git
+revision = HEAD

--- a/src/faultlog/subprojects/sdbusplus.wrap
+++ b/src/faultlog/subprojects/sdbusplus.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/openbmc/sdbusplus.git
+revision = HEAD

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <fmt/format.h>
+
+#include <phosphor-logging/log.hpp>
+
+namespace openpower::faultlog
+{
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+
+/**
+ * @brief Read property value from the specified object and interface
+ * @param[in] bus D-Bus handle
+ * @param[in] service service which has implemented the interface
+ * @param[in] object object having has implemented the interface
+ * @param[in] intf interface having the property
+ * @param[in] prop name of the property to read
+ * @return property value
+ */
+template <typename T>
+T readProperty(sdbusplus::bus::bus& bus, const std::string& service,
+               const std::string& object, const std::string& intf,
+               const std::string& prop)
+{
+    T retVal{};
+    try
+    {
+        auto properties =
+            bus.new_method_call(service.c_str(), object.c_str(),
+                                "org.freedesktop.DBus.Properties", "Get");
+        properties.append(intf);
+        properties.append(prop);
+        auto result = bus.call(properties);
+        result.read(retVal);
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to get the property ({}) interface ({}) "
+                        "object path ({}) error ({}) ",
+                        prop.c_str(), intf.c_str(), object.c_str(), ex.what())
+                .c_str());
+        throw;
+    }
+    return retVal;
+}
+
+} // namespace openpower::faultlog

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,1 @@
+subdir('faultlog')


### PR DESCRIPTION
1) Parse through the hardware isolation D-Bus objects to get the associated errorlog object
2) Read the PEL from the error log object path
3) Read the required NAG data from the PEL and add to JSON.

Tested:
root@rain100bmc:/tmp# guard -l
ID       | ERROR    |  Type  | Path
00000001 | 50006b8f | fatal | physical:sys-0/node-0/proc-0/eq-1/fc-0/core-0

[
  {
    "SERVICABLE_EVENT": {
      "CEC_ERROR_LOG": {
        "Callout Section": {
          "Callout Count": "1",
          "Callouts": [
            {
              "CCIN": "5C67",
              "FRU Type": "Normal Hardware FRU",
              "Location Code": "U78DA.ND0.WZS004A-P0-C15",
              "Part Number": "F210110",
              "Priority": "Medium Priority",
              "Serial Number": "            "
            }
          ]
        },
        "DATE_TIME": "03/26/2023 08:48:41",
        "ERR_PLID": "0x50006B8F",
        "SRC": "BD13E510"
      }
    }
  }
]


Change-Id: I748c23697b78189f57be2770019687e984aff571