### PR TITLE
Capture isolated/deconfigured/fco records in JSON file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,3 +113,5 @@ configure_file(
     install_dir: systemd_system_unit_dir,
     output: '@PLAINNAME@'
     )
+    
+subdir('src')    

--- a/src/faultlog/deconfig_reason.cpp
+++ b/src/faultlog/deconfig_reason.cpp
@@ -1,0 +1,66 @@
+#include <deconfig_reason.hpp>
+
+namespace openpower::faultlog
+{
+std::string getDeconfigReason(const DeconfiguredByReason& reason)
+{
+    switch (reason)
+    {
+        case DECONFIGURED_BY_MANUAL_GARD:
+            return "MANUAL";
+        case DECONFIGURED_BY_FIELD_CORE_OVERRIDE:
+            return "FIELD CORE OVERRIDE";
+        case DECONFIGURED_BY_MEMORY_CONFIG:
+            return "MEMORY CONFIG";
+        case DECONFIGURED_BY_NO_CHILD_MCA:
+            return "NO CHILD DIMM";
+        case DECONFIGURED_BY_BUS_DECONFIG:
+            return "BUS DECONFIGURED";
+        case DECONFIGURED_BY_PRD:
+            return "PRD";
+        case DECONFIGURED_BY_PHYP:
+            return "PHYP";
+        case DECONFIGURED_BY_SPCN:
+            return "SPCN";
+        case CONFIGURED_BY_RESOURCE_RECOVERY:
+            return "RESOURCE RECOVERY";
+        case DECONFIGURED_BY_NO_PARENT_MEMBUF:
+        case DECONFIGURED_BY_NO_CHILD_DIMM:
+        case DECONFIGURED_BY_NO_PARENT_DMI:
+        case DECONFIGURED_BY_NO_PARENT_MBA:
+        case DECONFIGURED_BY_EQ_DECONFIG:
+        case DECONFIGURED_BY_FC_DECONFIG:
+        case DECONFIGURED_BY_CORE_DECONFIG:
+        case DECONFIGURED_BY_PHB_DECONFIG:
+        case DECONFIGURED_BY_PEC_DECONFIG:
+        case DECONFIGURED_BY_NO_CHILD_MCS:
+        case DECONFIGURED_BY_NO_PARENT_MCBIST:
+        case DECONFIGURED_BY_DISABLED_PORT:
+        case DECONFIGURED_BY_NO_CHILD_MI:
+        case DECONFIGURED_BY_NO_CHILD_DMI:
+        case DECONFIGURED_BY_NO_PARENT_MC:
+        case DECONFIGURED_BY_NO_PARENT_MI:
+        case DECONFIGURED_BY_NO_MATCHING_LINK_SET:
+        case DECONFIGURED_BY_OBUS_MODE:
+        case DECONFIGURED_BY_NO_CHILD_OMI:
+        case DECONFIGURED_BY_NO_PARENT_MCC:
+        case DECONFIGURED_BY_NO_CHILD_MEM_PORT:
+        case DECONFIGURED_BY_NO_PARENT_OMI:
+        case DECONFIGURED_BY_NO_CHILD_OCMB_CHIP:
+        case DECONFIGURED_BY_NO_PARENT_OCMB_CHIP:
+        case DECONFIGURED_BY_NO_PARENT_OMIC:
+        case DECONFIGURED_BY_INACTIVE_PAU:
+        case DECONFIGURED_BY_NO_CHILD_OMIC:
+        case DECONFIGURED_BY_NO_CHILD_MCC:
+        case DECONFIGURED_BY_NO_PARENT_MEM_PORT:
+        case DECONFIGURED_BY_NO_PARENT_PAUC:
+        case DECONFIGURED_BY_NO_CHILD_PMIC:
+        case DECONFIGURED_BY_NO_PEER_TARGET:
+            return "ASSOCIATION";
+        default:
+            return "Unkown";
+    }
+    return "Unknown";
+}
+
+} // namespace openpower::faultlog

--- a/src/faultlog/deconfig_reason.hpp
+++ b/src/faultlog/deconfig_reason.hpp
@@ -1,0 +1,89 @@
+#pragma once
+#include <string>
+namespace openpower::faultlog
+{
+/**
+ * - Enums to indicate non-error reason for a hardwares deconfiguration.
+ * - These enuems used in HwasSate.deconfiguredByEid.
+ * - The enums list is picked from OpenPOWER/Hostboot component.
+ *   (src/include/usr/hwas/common/deconfigGard.H -
+ *    commit id: a0ac6056abbd587ae76a7c10032fd7e50ca5e529)
+ */
+enum DeconfiguredByReason
+{
+    INVALID_DECONFIGURED_BY_REASON,
+
+    DECONFIGURED_BY_CODE_BASE = 0x0000FF00,
+
+    DECONFIGURED_BY_MANUAL_GARD,         // BASE | 0x01
+    DECONFIGURED_BY_FIELD_CORE_OVERRIDE, // BASE | 0x02
+    DECONFIGURED_BY_MEMORY_CONFIG,       // BASE | 0x03
+
+    DECONFIGURED_BY_NO_CHILD_MCA,     // BASE | 0x04
+    DECONFIGURED_BY_NO_CHILD_MEMBUF = // Deprecated
+    DECONFIGURED_BY_NO_CHILD_MCA,
+    DECONFIGURED_BY_NO_CHILD_MEMBUF_OR_MCA = // Deprecated
+    DECONFIGURED_BY_NO_CHILD_MCA,
+
+    DECONFIGURED_BY_BUS_DECONFIG,     // BASE | 0x05
+    DECONFIGURED_BY_PRD,              // BASE | 0x06
+    DECONFIGURED_BY_PHYP,             // BASE | 0x07
+    DECONFIGURED_BY_SPCN,             // BASE | 0x08
+    DECONFIGURED_BY_NO_PARENT_MEMBUF, // BASE | 0x09
+    DECONFIGURED_BY_NO_CHILD_DIMM,    // BASE | 0x0A
+
+    DECONFIGURED_BY_NO_PARENT_DMI,  // BASE | 0x0B
+    DECONFIGURED_BY_NO_PARENT_MCS = // Deprecated
+    DECONFIGURED_BY_NO_PARENT_DMI,
+
+    DECONFIGURED_BY_NO_CHILD_MBA, // BASE | 0x0C
+
+    DECONFIGURED_BY_NO_PARENT_MBA_OR_MCA, // BASE | 0x0D
+    DECONFIGURED_BY_NO_PARENT_MBA =       // Deprecated
+    DECONFIGURED_BY_NO_PARENT_MBA_OR_MCA,
+
+    CONFIGURED_BY_RESOURCE_RECOVERY, // BASE | 0x0E
+
+    DECONFIGURED_BY_EQ_DECONFIG,          // BASE | 0x0F
+    DECONFIGURED_BY_FC_DECONFIG,          // BASE | 0x10
+    DECONFIGURED_BY_CORE_DECONFIG,        // BASE | 0x11
+    DECONFIGURED_BY_PHB_DECONFIG,         // BASE | 0x12
+    DECONFIGURED_BY_PEC_DECONFIG,         // BASE | 0x13
+    DECONFIGURED_BY_NO_CHILD_MCS,         // BASE | 0x14
+    DECONFIGURED_BY_NO_PARENT_MCBIST,     // BASE | 0x15
+    DECONFIGURED_BY_DISABLED_PORT,        // BASE | 0x16
+    DECONFIGURED_BY_NO_CHILD_MI,          // BASE | 0x17
+    DECONFIGURED_BY_NO_CHILD_DMI,         // BASE | 0x18
+    DECONFIGURED_BY_NO_PARENT_MC,         // BASE | 0x19
+    DECONFIGURED_BY_NO_PARENT_MI,         // BASE | 0x1A
+    DECONFIGURED_BY_NO_MATCHING_LINK_SET, // BASE | 0x1B
+    DECONFIGURED_BY_OBUS_MODE,            // BASE | 0x1C
+    DECONFIGURED_BY_NO_CHILD_OMI,         // BASE | 0x1D
+    DECONFIGURED_BY_NO_PARENT_MCC,        // BASE | 0x1E
+    DECONFIGURED_BY_NO_CHILD_MEM_PORT,    // BASE | 0x1F
+    DECONFIGURED_BY_NO_PARENT_OMI,        // BASE | 0x20
+    DECONFIGURED_BY_NO_CHILD_OCMB_CHIP,   // BASE | 0x21
+    DECONFIGURED_BY_NO_PARENT_OCMB_CHIP,  // BASE | 0x22
+    DECONFIGURED_BY_NO_PARENT_OMIC,       // BASE | 0x23
+    DECONFIGURED_BY_INACTIVE_PAU,         // BASE | 0x24
+    DECONFIGURED_BY_NO_CHILD_OMIC,        // BASE | 0x25
+    DECONFIGURED_BY_NO_CHILD_MCC,         // BASE | 0x26
+    DECONFIGURED_BY_NO_PARENT_MEM_PORT,   // BASE | 0x27
+    DECONFIGURED_BY_NO_PARENT_PAUC,       // BASE | 0x28
+    DECONFIGURED_BY_NO_CHILD_PMIC,        // BASE | 0x29
+    DECONFIGURED_BY_NO_PEER_TARGET,       // BASE | 0x2A
+
+    // mask - these bits mean it's a PLID/EID and not an enum
+    //        for the deconfigured hardwares
+    DECONFIGURED_BY_PLID_MASK = 0xFFFF0000,
+};
+
+/**
+ * @brief Get string value for the deconfig enum value
+ *
+ * @paran[in] reason - the deconfigured reason enum value
+ *
+ * @return std::string deconfig reason
+ */
+std::string getDeconfigReason(const DeconfiguredByReason& reason);
+} // namespace openpower::faultlog

--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -72,6 +72,13 @@ static int getDeconfigTargets(struct pdbg_target* target, void* priv)
     return 0;
 }
 
+int DeconfigRecords::getCount()
+{
+    DeconfigDataList deconfigList;
+    pdbg_target_traverse(nullptr, getDeconfigTargets, &deconfigList);
+    return static_cast<int>(deconfigList.targetList.size());
+}
+
 void DeconfigRecords::populate(nlohmann::json& jsonNag)
 {
     DeconfigDataList deconfigList;

--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -1,0 +1,126 @@
+#include <attributes_info.H>
+
+#include <deconfig_reason.hpp>
+#include <deconfig_records.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+extern "C"
+{
+#include <libpdbg.h>
+}
+namespace openpower::faultlog
+{
+
+using ::nlohmann::json;
+
+constexpr auto stateConfigured = "CONFIGURED";
+constexpr auto stateDeconfigured = "DECONFIGURED";
+
+struct DeconfigDataList
+{
+    std::vector<pdbg_target*> targetList;
+    void addPdbgTarget(pdbg_target* tgt)
+    {
+        targetList.push_back(tgt);
+    }
+};
+
+/**
+ * @brief Get pedgt targets which has been deconfigured
+ *
+ * This callback function is called as part of the recursive method
+ * pdbg_target_traverse, recursion will exit when the method return 1
+ * else continues till the target is found
+ *
+ * @param[in] target - pdbg target to compare
+ * @param[inout] priv - data structure to pass to the callback method
+ *
+ * @return 1 when target is found else 0
+ */
+static int getDeconfigTargets(struct pdbg_target* target, void* priv)
+{
+    auto deconfigList = reinterpret_cast<DeconfigDataList*>(priv);
+    ATTR_HWAS_STATE_Type hwasState;
+    if (!DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState))
+    {
+        if ((hwasState.deconfiguredByEid != 0) &&
+            (DECONFIGURED_BY_PLID_MASK & hwasState.deconfiguredByEid) == 0)
+        {
+            // inlcude only specific states and other might be by association
+            switch (hwasState.deconfiguredByEid)
+            {
+                case DECONFIGURED_BY_MANUAL_GARD:
+                case DECONFIGURED_BY_FIELD_CORE_OVERRIDE:
+                case DECONFIGURED_BY_PRD:
+                case DECONFIGURED_BY_PHYP:
+                case DECONFIGURED_BY_SPCN:
+                {
+                    deconfigList->addPdbgTarget(target);
+                    break;
+                }
+                default:
+                {
+                    lg2::info(
+                        "Ignoring deconfig target {TARGET} {DECONFIG_EID} ",
+                        "TARGET", pdbg_target_name(target), "DECONFIG_EID",
+                        static_cast<int>(hwasState.deconfiguredByEid));
+                    break;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+void DeconfigRecords::populate(nlohmann::json& jsonNag)
+{
+    DeconfigDataList deconfigList;
+    pdbg_target_traverse(nullptr, getDeconfigTargets, &deconfigList);
+
+    for (auto target : deconfigList.targetList)
+    {
+        try
+        {
+            json deconfigJson = json::object();
+            deconfigJson["TYPE"] = pdbg_target_name(target);
+            std::string state = stateDeconfigured;
+            ATTR_HWAS_STATE_Type hwasState;
+            if (!DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState))
+            {
+                if (hwasState.functional)
+                {
+                    state = stateConfigured;
+                }
+            }
+            deconfigJson["CURRENT_STATE"] = std::move(state);
+
+            ATTR_PHYS_DEV_PATH_Type attrPhyDevPath;
+            if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, attrPhyDevPath))
+            {
+                deconfigJson["PHYS_PATH"] = attrPhyDevPath;
+            }
+
+            ATTR_LOCATION_CODE_Type attrLocCode;
+            if (!DT_GET_PROP(ATTR_LOCATION_CODE, target, attrLocCode))
+            {
+                deconfigJson["LOCATION_CODE"] = attrLocCode;
+            }
+
+            std::stringstream ss;
+            ss << "0x" << std::hex << hwasState.deconfiguredByEid;
+            deconfigJson["PLID"] = ss.str();
+            deconfigJson["REASON_DESCRIPTION"] = getDeconfigReason(
+                static_cast<DeconfiguredByReason>(hwasState.deconfiguredByEid));
+
+            json header = json::object();
+            header["DECONFIGURED"] = std::move(deconfigJson);
+            jsonNag.push_back(std::move(header));
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::error("Failed to add deconfig records {TARGET} {ERROR}",
+                       "TARGET", pdbg_target_name(target), "ERROR", ex.what());
+        }
+    }
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/deconfig_records.hpp
+++ b/src/faultlog/deconfig_records.hpp
@@ -23,7 +23,13 @@ class DeconfigRecords
     ~DeconfigRecords() = delete;
 
   public:
-    /** @brief Poupulate target details that have deconfiguredByEid set
+    /** @brief Get deconfigured records count by parsing through pdbg targets
+     *
+     *  @return 0 if no records are found else count of records
+     */
+    static int getCount();
+
+    /** @brief Populate target details that have deconfiguredByEid set
      *
      *  @param[in] jsonNag - Update JSON deconfigure records
      */

--- a/src/faultlog/deconfig_records.hpp
+++ b/src/faultlog/deconfig_records.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace openpower::faultlog
+{
+/**
+ * @class DeconfigRecords
+ *
+ * Capture Deconfig records in JSON file
+ *
+ * Filed code override is a method of enabling only a
+ * limited number of processor cores in the system.
+ */
+class DeconfigRecords
+{
+  private:
+    DeconfigRecords() = delete;
+    DeconfigRecords(const DeconfigRecords&) = delete;
+    DeconfigRecords& operator=(const DeconfigRecords&) = delete;
+    DeconfigRecords(DeconfigRecords&&) = delete;
+    DeconfigRecords& operator=(DeconfigRecords&&) = delete;
+    ~DeconfigRecords() = delete;
+
+  public:
+    /** @brief Poupulate target details that have deconfiguredByEid set
+     *
+     *  @param[in] jsonNag - Update JSON deconfigure records
+     */
+    static void populate(nlohmann::json& jsonNag);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -4,6 +4,7 @@
 #include <libguard/include/guard_record.hpp>
 #include <nlohmann/json.hpp>
 #include <sdbusplus/bus.hpp>
+#include <faultlog_policy.hpp>
 
 #include <iostream>
 
@@ -38,6 +39,7 @@ int main(int /*arg*/, char** /*argv*/)
 
         GuardWithEidRecords::populate(bus, unresolvedRecords, faultLogJson);
         GuardWithoutEidRecords::populate(unresolvedRecords, faultLogJson);
+        FaultLogPolicy::populate(bus, faultLogJson);
         std::cout << faultLogJson.dump(2) << std::endl;
     }
     catch (const std::exception& e)

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -1,3 +1,4 @@
+#include <deconfig_records.hpp>
 #include <faultlog_policy.hpp>
 #include <guard_with_eid_records.hpp>
 #include <guard_without_eid_records.hpp>
@@ -37,11 +38,11 @@ int main(int /*arg*/, char** /*argv*/)
                 unresolvedRecords.emplace_back(elem);
             }
         }
-
         GuardWithEidRecords::populate(bus, unresolvedRecords, faultLogJson);
         GuardWithoutEidRecords::populate(unresolvedRecords, faultLogJson);
         FaultLogPolicy::populate(bus, faultLogJson);
         UnresolvedPELs::populate(bus, unresolvedRecords, faultLogJson);
+        DeconfigRecords::populate(faultLogJson);
         std::cout << faultLogJson.dump(2) << std::endl;
     }
     catch (const std::exception& e)

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -1,10 +1,11 @@
+#include <faultlog_policy.hpp>
 #include <guard_with_eid_records.hpp>
 #include <guard_without_eid_records.hpp>
 #include <libguard/guard_interface.hpp>
 #include <libguard/include/guard_record.hpp>
 #include <nlohmann/json.hpp>
 #include <sdbusplus/bus.hpp>
-#include <faultlog_policy.hpp>
+#include <unresolved_pels.hpp>
 
 #include <iostream>
 
@@ -40,6 +41,7 @@ int main(int /*arg*/, char** /*argv*/)
         GuardWithEidRecords::populate(bus, unresolvedRecords, faultLogJson);
         GuardWithoutEidRecords::populate(unresolvedRecords, faultLogJson);
         FaultLogPolicy::populate(bus, faultLogJson);
+        UnresolvedPELs::populate(bus, unresolvedRecords, faultLogJson);
         std::cout << faultLogJson.dump(2) << std::endl;
     }
     catch (const std::exception& e)

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -1,3 +1,5 @@
+#include "xyz/openbmc_project/Logging/Entry/server.hpp"
+#include <CLI/CLI.hpp>
 #include <deconfig_records.hpp>
 #include <faultlog_policy.hpp>
 #include <guard_with_eid_records.hpp>
@@ -5,6 +7,7 @@
 #include <libguard/guard_interface.hpp>
 #include <libguard/include/guard_record.hpp>
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 #include <unresolved_pels.hpp>
 
@@ -16,10 +19,17 @@ using ::openpower::guard::GuardRecords;
 
 #define GUARD_RESOLVED 0xFFFFFFFF
 
-int main(int /*arg*/, char** /*argv*/)
+using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+
+int main(int argc, char** argv)
 {
     try
     {
+        lg2::info("faultlog app to collect deconfig/guard records details");
+
+        CLI::App app{"Faultlog tool"};
+        app.set_help_flag("-h, --help", "Faultlog tool options");
+
         auto bus = sdbusplus::bus::new_default();
 
         nlohmann::json faultLogJson = json::array();
@@ -38,17 +48,146 @@ int main(int /*arg*/, char** /*argv*/)
                 unresolvedRecords.emplace_back(elem);
             }
         }
-        GuardWithEidRecords::populate(bus, unresolvedRecords, faultLogJson);
-        GuardWithoutEidRecords::populate(unresolvedRecords, faultLogJson);
-        FaultLogPolicy::populate(bus, faultLogJson);
-        UnresolvedPELs::populate(bus, unresolvedRecords, faultLogJson);
-        DeconfigRecords::populate(faultLogJson);
-        std::cout << faultLogJson.dump(2) << std::endl;
+
+        bool guardWithEid = false;
+        bool guardWithoutEid = false;
+        bool policy = false;
+        bool unresolvedPels = false;
+        bool deconfig = false;
+        bool createPel = false;
+        bool listFaultlog = false;
+
+        app.set_help_flag("-h, --help", "Faultlog tool options");
+        app.add_flag("-g, --guardwterr", guardWithEid,
+                     "Populate guard records with associated error objects "
+                     "details to JSON");
+        app.add_flag("-m, --guardmanual", guardWithoutEid,
+                     "Populate guard records without associated error objects "
+                     "details to JSON");
+        app.add_flag("-p, --policy", policy,
+                     "Populate faultlog policy and FCO values to JSON");
+        app.add_flag(
+            "-u, --unresolvedPels", unresolvedPels,
+            "Populate unresolved pels with deconfig bit set details to JSON");
+        app.add_flag("-d, --deconfig", deconfig,
+                     "Populate deconfigured target details to JSON");
+        app.add_flag("-c, --createPel", createPel,
+                     "Create faultlog pel if there are guarded/deconfigured "
+                     "records present");
+        app.add_flag("-f, --faultlog", listFaultlog,
+                     "List all fault log records in JSON format");
+
+        CLI11_PARSE(app, argc, argv);
+
+        // guard records with associated error object
+        if (guardWithEid)
+        {
+            (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
+                                                faultLogJson);
+        }
+
+        // guard records without any associated error object
+        else if (guardWithoutEid)
+        {
+            (void)GuardWithoutEidRecords::populate(unresolvedRecords,
+                                                   faultLogJson);
+        }
+
+        // guard policy
+        else if (policy)
+        {
+            (void)FaultLogPolicy::populate(bus, faultLogJson);
+        }
+
+        // unresolved pels with deconfig bit set
+        else if (unresolvedPels)
+        {
+            (void)UnresolvedPELs::populate(bus, unresolvedRecords,
+                                           faultLogJson);
+        }
+
+        // pdbg targets with deconfig bit set
+        else if (deconfig)
+        {
+            (void)DeconfigRecords::populate(faultLogJson);
+        }
+
+        // create fault log pel if there are service actions pending
+        else if (createPel)
+        {
+            int guardCount = GuardWithEidRecords::getCount(unresolvedRecords);
+            int manualGuardCount =
+                GuardWithoutEidRecords::getCount(unresolvedRecords);
+            int unresolvedPelsCount = UnresolvedPELs::getCount(bus);
+            int deconfigCount = DeconfigRecords::getCount();
+
+            if ((guardCount > 0) || (manualGuardCount > 0) ||
+                (unresolvedPelsCount > 0) || (deconfigCount > 0))
+            {
+                std::unordered_map<std::string, std::string> data;
+                data.emplace("GUARD_WITH_ASSOC_ERROR_COUNT",
+                             std::to_string(guardCount));
+                data.emplace("GUARD_WITH_NO_ASSOC_ERROR_COUNT",
+                             std::to_string(manualGuardCount));
+                data.emplace("UNRESOLVED_PEL_WITH_DECONFIG_BIT_COUNT",
+                             std::to_string(unresolvedPelsCount));
+                data.emplace("DECONFIG_RECORD_COUNT",
+                             std::to_string(deconfigCount));
+
+                auto method = bus.new_method_call(
+                    "xyz.openbmc_project.Logging",
+                    "/xyz/openbmc_project/logging",
+                    "xyz.openbmc_project.Logging.Create", "Create");
+                method.append("org.open_power.Faultlog.Error.DeconfiguredHW",
+                              Severity::Error, data);
+                auto reply = method.call();
+                if (reply.is_method_error())
+                {
+                    lg2::error("Error in calling D-Bus method to create PEL");
+                }
+                lg2::info("faultlog {GUARD_COUNT}, {MAN_GUARD_COUNT}, "
+                          "{DECONFIG_COUNT} , {PEL_COUNT} ",
+                          "GUARD_COUNT", guardCount, "MAN_GUARD_COUNT",
+                          manualGuardCount, "DECONFIG_COUNT", deconfigCount,
+                          "PEL_COUNT", unresolvedPelsCount);
+            }
+            else
+            {
+                lg2::info("There are no pending service actions ignoring "
+                          "creating fautlog pel");
+            }
+        }
+        // write faultlog json to stdout
+        else if (listFaultlog)
+        {
+            (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
+                                                faultLogJson);
+            (void)GuardWithoutEidRecords::populate(unresolvedRecords,
+                                                   faultLogJson);
+
+            (void)FaultLogPolicy::populate(bus, faultLogJson);
+
+            (void)UnresolvedPELs::populate(bus, unresolvedRecords,
+                                           faultLogJson);
+            (void)DeconfigRecords::populate(faultLogJson);
+        }
+        else
+        {
+            lg2::error("Invalid option");
+        }
+
+        if (listFaultlog || deconfig || unresolvedPels || policy ||
+            guardWithoutEid || guardWithEid)
+        {
+            std::cout << faultLogJson.dump(2) << std::endl;
+        }
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what() << std::endl;
+        lg2::error("Failed {ERROR}", "ERROR", e.what());
         exit(EXIT_FAILURE);
     }
+    // wait for a while for the D-Bus method to complete-
+    sleep(2);
     return 0;
 }

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -1,4 +1,5 @@
 #include <guard_with_eid_records.hpp>
+#include <guard_without_eid_records.hpp>
 #include <libguard/guard_interface.hpp>
 #include <libguard/include/guard_record.hpp>
 #include <nlohmann/json.hpp>
@@ -36,6 +37,7 @@ int main(int /*arg*/, char** /*argv*/)
         }
 
         GuardWithEidRecords::populate(bus, unresolvedRecords, faultLogJson);
+        GuardWithoutEidRecords::populate(unresolvedRecords, faultLogJson);
         std::cout << faultLogJson.dump(2) << std::endl;
     }
     catch (const std::exception& e)

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -1,0 +1,47 @@
+#include <guard_with_eid_records.hpp>
+#include <libguard/guard_interface.hpp>
+#include <libguard/include/guard_record.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+#include <iostream>
+
+using namespace openpower::faultlog;
+using ::nlohmann::json;
+using ::openpower::guard::GuardRecords;
+
+#define GUARD_RESOLVED 0xFFFFFFFF
+
+int main(int /*arg*/, char** /*argv*/)
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+
+        nlohmann::json faultLogJson = json::array();
+
+        openpower::guard::libguard_init();
+        // Don't get ephemeral records because those type records are not
+        // intended to expose to the end user, just created for internal purpose
+        // to use by the BMC and Hostboot.
+        openpower::guard::GuardRecords records = openpower::guard::getAll(true);
+        GuardRecords unresolvedRecords;
+        // filter out all unused or resolved records
+        for (const auto& elem : records)
+        {
+            if (elem.recordId != GUARD_RESOLVED)
+            {
+                unresolvedRecords.emplace_back(elem);
+            }
+        }
+
+        GuardWithEidRecords::populate(bus, unresolvedRecords, faultLogJson);
+        std::cout << faultLogJson.dump(2) << std::endl;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    return 0;
+}

--- a/src/faultlog/faultlog_policy.cpp
+++ b/src/faultlog/faultlog_policy.cpp
@@ -1,0 +1,68 @@
+#include <phosphor-logging/lg2.hpp>
+#include <faultlog_policy.hpp>
+#include <util.hpp>
+
+namespace openpower::faultlog
+{
+using ::nlohmann::json;
+
+void FaultLogPolicy::populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson)
+{
+    try
+    {
+        json jsonPolicyVal = json::object();
+        // FCO_VALUE
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.BIOSConfigManager",
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "GetAttribute");
+        method.append("hb_field_core_override");
+
+        std::tuple<std::string, std::variant<int64_t, std::string>,
+                   std::variant<int64_t, std::string>>
+            fcoAttrVal;
+        auto result = bus.call(method);
+        result.read(std::get<0>(fcoAttrVal), std::get<1>(fcoAttrVal),
+                    std::get<2>(fcoAttrVal));
+
+        std::variant<int64_t, std::string> attr = std::get<1>(fcoAttrVal);
+        uint32_t fcoVal = 0;
+        if (auto pVal = std::get_if<int64_t>(&attr))
+        {
+            fcoVal = *pVal;
+        }
+        jsonPolicyVal["FCO_VALUE"] = fcoVal;
+
+        bool enabled = true;
+        try
+        {
+            // master guard enabled or not
+            enabled = readProperty<bool>(
+                bus, "xyz.openbmc_project.Settings",
+                "/xyz/openbmc_project/hardware_isolation/allow_hw_isolation",
+                "xyz.openbmc_project.Object.Enable", "Enabled");
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::error("Failed to read allow_hw_isolation property {ERROR}",
+                       "ERROR", ex.what());
+        }
+        jsonPolicyVal["MASTER"] = enabled;
+
+        // predictive guard enabled or not
+        // at present not present in BMC will leave it as true for now
+        jsonPolicyVal["PREDICTIVE"] = true;
+
+        json jsonPolicy = json::object();
+        jsonPolicy["POLICY"] = std::move(jsonPolicyVal);
+        nagJson.push_back(std::move(jsonPolicy));
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("Failed to add isolation policy details to JSON {ERROR}",
+                   "ERROR", ex.what());
+    }
+
+    return;
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/faultlog_policy.hpp
+++ b/src/faultlog/faultlog_policy.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace openpower::faultlog
+{
+/**
+ * @class FaultLogPolicy
+ *
+ * Capture faultlog policy and FCO value
+ */
+class FaultLogPolicy
+{
+  private:
+    FaultLogPolicy() = delete;
+    FaultLogPolicy(const FaultLogPolicy&) = delete;
+    FaultLogPolicy& operator=(const FaultLogPolicy&) = delete;
+    FaultLogPolicy(FaultLogPolicy&&) = delete;
+    FaultLogPolicy& operator=(FaultLogPolicy&&) = delete;
+    ~FaultLogPolicy() = delete;
+
+  public:
+    /** @brief Populate hardware isolation policy and FCO value
+     *
+     *  @param[in] bus - D-Bus to attach to
+     *  @param[in] json - nag JSON file
+     *  @return void
+     */
+    static void populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -53,6 +53,22 @@ static int getGuardedTarget(struct pdbg_target* target, void* priv)
     }
     return 0;
 }
+
+int GuardWithEidRecords::getCount(const GuardRecords& guardRecords)
+{
+    int count = 0;
+    for (const auto& elem : guardRecords)
+    {
+        // ignore manual guard records
+        if (elem.elogId == 0)
+        {
+            continue;
+        }
+        count += 1;
+    }
+    return count;
+}
+
 void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                                    const GuardRecords& guardRecords,
                                    json& jsonNag)

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -1,0 +1,169 @@
+#include <attributes_info.H>
+
+#include <guard_with_eid_records.hpp>
+#include <libguard/guard_interface.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <util.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+extern "C"
+{
+#include <libpdbg.h>
+}
+
+namespace openpower::faultlog
+{
+using ::nlohmann::json;
+
+constexpr auto stateConfigured = "CONFIGURED";
+constexpr auto stateDeconfigured = "DECONFIGURED";
+
+/** Data structure to pass to pdbg_target_traverse callback method*/
+struct GuardedTarget
+{
+    pdbg_target* target = nullptr;
+    std::string phyDevPath = {};
+    GuardedTarget(const std::string& path) : phyDevPath(path)
+    {}
+};
+using ::sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+/**
+ * @brief Get PDBG target matching the guarded target physicalpath
+ *
+ * This callback function is called as part of the recursive method
+ * pdbg_target_traverse, recursion will exit when the method return 1
+ * else continues till the target is found
+ *
+ * @param[in] target - pdbg target to compare
+ * @param[inout] priv - data structure passed to the callback method
+ *
+ * @return 1 when target is found else 0
+ */
+static int getGuardedTarget(struct pdbg_target* target, void* priv)
+{
+    GuardedTarget* guardTarget = reinterpret_cast<GuardedTarget*>(priv);
+    ATTR_PHYS_DEV_PATH_Type phyPath;
+    if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, phyPath))
+    {
+        if (strcmp(phyPath, guardTarget->phyDevPath.c_str()) == 0)
+        {
+            guardTarget->target = target;
+            return 1;
+        }
+    }
+    return 0;
+}
+void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
+                                   const GuardRecords& guardRecords,
+                                   json& jsonNag)
+{
+
+    for (const auto& elem : guardRecords)
+    {
+        try
+        {
+            // ignore manual guard records
+            if (elem.elogId == 0)
+            {
+                continue;
+            }
+
+            // add ERROR_LOG secion
+            uint32_t bmcLogId;
+            auto method1 = bus.new_method_call(
+                "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+                "org.open_power.Logging.PEL", "GetBMCLogIdFromPELId");
+
+            method1.append(static_cast<uint32_t>(elem.elogId));
+            auto resp1 = bus.call(method1);
+            resp1.read(bmcLogId);
+            json jsonErrorLog = json::object();
+            std::string pel;
+
+            auto method2 = bus.new_method_call(
+                "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+                "org.open_power.Logging.PEL", "GetPELJSON");
+            method2.append(bmcLogId);
+            auto resp2 = bus.call(method2);
+            resp2.read(pel);
+            json pelJson = std::move(json::parse(pel));
+
+            jsonErrorLog["ERR_PLID"] =
+                pelJson["Private Header"]["Platform Log Id"];
+            jsonErrorLog["Callout Section"] =
+                pelJson["Primary SRC"]["Callout Section"];
+            jsonErrorLog["SRC"] = pelJson["Primary SRC"]["Reference Code"];
+            jsonErrorLog["DATE_TIME"] = pelJson["Private Header"]["Created at"];
+
+            json jsonErrorLogSection = json::array();
+            jsonErrorLogSection.push_back(std::move(jsonErrorLog));
+
+            // add resource actions section
+            auto physicalPath =
+                openpower::guard::getPhysicalPath(elem.targetId);
+            if (!physicalPath.has_value())
+            {
+                lg2::error("Failed to get physical path for record {RECORD_ID}",
+                           "RECORD_ID", elem.recordId);
+                continue;
+            }
+
+            GuardedTarget guardedTarget(*physicalPath);
+            pdbg_target_traverse(nullptr, getGuardedTarget, &guardedTarget);
+            if (guardedTarget.target == nullptr)
+            {
+                lg2::error("Failed to find the pdbg target for the guarded "
+                           "target {RECORD_ID}",
+                           "RECORD_ID", elem.recordId);
+                continue;
+            }
+            json jsonResource = json::object();
+            jsonResource["TYPE"] = pdbg_target_name(guardedTarget.target);
+            std::string state = stateDeconfigured;
+            ATTR_HWAS_STATE_Type hwasState;
+            if (!DT_GET_PROP(ATTR_HWAS_STATE, guardedTarget.target, hwasState))
+            {
+                if (hwasState.functional)
+                {
+                    state = stateConfigured;
+                }
+            }
+            jsonResource["CURRENT_STATE"] = std::move(state);
+
+            ATTR_LOCATION_CODE_Type attrLocCode;
+            if (!DT_GET_PROP(ATTR_LOCATION_CODE, guardedTarget.target,
+                             attrLocCode))
+            {
+                jsonResource["LOCATION_CODE"] = attrLocCode;
+            }
+
+            jsonResource["REASON_DESCRIPTION"] =
+                getGuardReason(guardRecords, *physicalPath);
+
+            jsonResource["GARD_RECORD"] = true;
+
+            json jsonEventData = json::object();
+            jsonEventData["RESOURCE_ACTIONS"] = std::move(jsonResource);
+            jsonErrorLogSection.push_back(jsonEventData);
+
+            json jsonErrlogObj = json::object();
+            jsonErrlogObj["CEC_ERROR_LOG"] = std::move(jsonErrorLogSection);
+
+            json jsonServiceEvent = json::object();
+            jsonServiceEvent["SERVICABLE_EVENT"] = std::move(jsonErrlogObj);
+            jsonNag.push_back(std::move(jsonServiceEvent));
+        }
+        catch (const InvalidArgument& ex)
+        {
+            lg2::info(
+                "PEL might be deleted but guard entry is around {ELOG_ID)",
+                "ELOG_ID", elem.elogId);
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::info("Failed to add guard records {ELOG_ID}, {ERROR}",
+                      "ELOG_ID", elem.elogId, "ERROR", ex.what());
+        }
+    }
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/guard_with_eid_records.hpp
+++ b/src/faultlog/guard_with_eid_records.hpp
@@ -25,6 +25,14 @@ class GuardWithEidRecords
     ~GuardWithEidRecords() = delete;
 
   public:
+    /** @brief Get guard records with associated error log count
+     *
+     *  @param[in] guardRecords - hardware isolated records to parse
+     *
+     *  @return 0 if no records are found else count of records
+     */
+    static int getCount(const GuardRecords& guardRecords);
+
     /** @brief Populate permanent hardware errors to NAG json file
      *
      *  @param[in] bus - D-Bus to attach to

--- a/src/faultlog/guard_with_eid_records.hpp
+++ b/src/faultlog/guard_with_eid_records.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <libguard/include/guard_record.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace openpower::faultlog
+{
+using ::openpower::guard::GuardRecords;
+
+/**
+ * @class GuardWithEidRecords
+ *
+ *  Captures all permanent hardware isolation or hardware error records
+ *  (guard) that has associated errorlog object created in JSON file.
+ */
+class GuardWithEidRecords
+{
+  private:
+    GuardWithEidRecords() = delete;
+    GuardWithEidRecords(const GuardWithEidRecords&) = delete;
+    GuardWithEidRecords& operator=(const GuardWithEidRecords&) = delete;
+    GuardWithEidRecords(GuardWithEidRecords&&) = delete;
+    GuardWithEidRecords& operator=(GuardWithEidRecords&&) = delete;
+    ~GuardWithEidRecords() = delete;
+
+  public:
+    /** @brief Populate permanent hardware errors to NAG json file
+     *
+     *  @param[in] bus - D-Bus to attach to
+     *  @param[in] guardRecords - hardware isolated records to parse
+     *  @param[in] jsonNag - Json file capturing serviceable events
+     */
+    static void populate(sdbusplus::bus::bus& bus,
+                         const GuardRecords& guardRecords,
+                         nlohmann::json& jsonNag);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -73,6 +73,28 @@ static int guardedTargets(struct pdbg_target* target, void* priv)
     return 0;
 }
 
+int GuardWithoutEidRecords::getCount(GuardRecords& guardRecords)
+{
+    int count = 0;
+    for (const auto& elem : guardRecords)
+    {
+        if (elem.elogId != 0)
+        {
+            // only cater guards without a PEL
+            continue;
+        }
+        auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
+        if (!physicalPath.has_value())
+        {
+            lg2::error("Failed to get physical path for record {RECORD_ID}",
+                       "RECORD_ID", elem.recordId);
+            continue;
+        }
+        count += 1;
+    }
+    return count;
+}
+
 void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
                                       nlohmann::json& jsonNag)
 {

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -1,0 +1,148 @@
+#include <attributes_info.H>
+
+#include <guard_without_eid_records.hpp>
+#include <libguard/guard_interface.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <util.hpp>
+
+extern "C"
+{
+#include <libpdbg.h>
+}
+
+namespace openpower::faultlog
+{
+
+using ::nlohmann::json;
+
+constexpr auto stateConfigured = "CONFIGURED";
+constexpr auto stateDeconfigured = "DECONFIGURED";
+
+/** Data structure to pass to pdbg_target_traverse callback method*/
+struct GuardedWithoutEidDataList
+{
+    std::vector<pdbg_target*> targetList;
+    std::vector<std::string> pathList;
+    void addPhysicalPath(const std::string& path)
+    {
+        pathList.emplace_back(path);
+    }
+    void addPdbgTarget(pdbg_target* tgt)
+    {
+        targetList.push_back(tgt);
+    }
+};
+
+/**
+ * @brief Get PDBG targets matching the phtysical path list
+ *
+ * This callback function is called as part of the recursive method
+ * pdbg_target_traverse, recursion will exit when the method return 1
+ * else continues till the target is found
+ *
+ * @param[in] target - pdbg target to compare
+ d* @param[inout] priv - data structure to pass to the callback method
+ *
+ * @return 0 when all the targets are parsed
+ */
+static int guardedTargets(struct pdbg_target* target, void* priv)
+{
+    // Parse through all the device tree targets recursively and
+    // check if the physical path of the target matches any of the
+    // deconfigured targets physical path if so store the target
+    // in the list.
+    //
+    // Avoiding multiple traversal through the device tree targets
+    GuardedWithoutEidDataList* deconfig =
+        reinterpret_cast<GuardedWithoutEidDataList*>(priv);
+    ATTR_PHYS_DEV_PATH_Type phyPath;
+    if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, phyPath))
+    {
+        for (auto path : deconfig->pathList)
+        {
+            if (strcmp(phyPath, path.c_str()) == 0)
+            {
+                deconfig->addPdbgTarget(target);
+            }
+        }
+        if (deconfig->pathList.size() == deconfig->targetList.size())
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
+                                      nlohmann::json& jsonNag)
+{
+    try
+    {
+        // capure the physical path of all the isolated/guard records
+        // that does not have an errorlog object created. Those with
+        // corresponding errorlog object are covered in ServiceableRecords
+        GuardedWithoutEidDataList guardList;
+        for (const auto& elem : guardRecords)
+        {
+            if (elem.elogId != 0)
+            {
+                // only cater guards without a PEL
+                continue;
+            }
+            auto physicalPath =
+                openpower::guard::getPhysicalPath(elem.targetId);
+            if (!physicalPath.has_value())
+            {
+                lg2::error("Failed to get physical path for record {RECORD_ID}",
+                           "RECORD_ID", elem.recordId);
+                continue;
+            }
+            guardList.addPhysicalPath(*physicalPath);
+        }
+
+        // traverse through all targets and get guarded targets list
+        pdbg_target_traverse(nullptr, guardedTargets, &guardList);
+
+        for (auto target : guardList.targetList)
+        {
+            json deconfigJson = json::object();
+            deconfigJson["TYPE"] = pdbg_target_name(target);
+            std::string state = stateDeconfigured;
+            ATTR_HWAS_STATE_Type hwasState;
+            if (!DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState))
+            {
+                if (hwasState.functional)
+                {
+                    state = stateConfigured;
+                }
+            }
+            deconfigJson["CURRENT_STATE"] = std::move(state);
+
+            ATTR_PHYS_DEV_PATH_Type attrPhyDevPath;
+            if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, attrPhyDevPath))
+            {
+                deconfigJson["PHYS_PATH"] = attrPhyDevPath;
+            }
+
+            ATTR_LOCATION_CODE_Type attrLocCode;
+            if (!DT_GET_PROP(ATTR_LOCATION_CODE, target, attrLocCode))
+            {
+                deconfigJson["LOCATION_CODE"] = attrLocCode;
+            }
+
+            deconfigJson["PLID"] = std::to_string(hwasState.deconfiguredByEid);
+            deconfigJson["REASON_DESCRIPTION"] =
+                getGuardReason(guardRecords, attrPhyDevPath);
+
+            json header = json::object();
+            header["DECONFIGURED"] = std::move(deconfigJson);
+            jsonNag.push_back(std::move(header));
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("Failed to add manual guard records {ERROR}", "ERROR",
+                   ex.what());
+    }
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/guard_without_eid_records.hpp
+++ b/src/faultlog/guard_without_eid_records.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <libguard/include/guard_record.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+using ::openpower::guard::GuardRecords;
+
+namespace openpower::faultlog
+{
+/**
+ * @class GuardWithoutEidRecords
+ *
+ * Captures hardware isolation/guard records that does not have
+ * a corresponding error object created. Example: Manual guard
+ */
+class GuardWithoutEidRecords
+{
+  private:
+    GuardWithoutEidRecords() = delete;
+    GuardWithoutEidRecords(const GuardWithoutEidRecords&) = delete;
+    GuardWithoutEidRecords& operator=(const GuardWithoutEidRecords&) = delete;
+    GuardWithoutEidRecords(GuardWithoutEidRecords&&) = delete;
+    GuardWithoutEidRecords& operator=(GuardWithoutEidRecords&&) = delete;
+    ~GuardWithoutEidRecords() = delete;
+
+  public:
+    /** @brief Captured deconfig data in NAG JSON file
+     *
+     *  @param[in] guardRecords - Guard records
+     *  @param[in] jsonNag - Update JSON servicable event
+     */
+    static void populate(const GuardRecords& guardRecords,
+                         nlohmann::json& jsonNag);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/guard_without_eid_records.hpp
+++ b/src/faultlog/guard_without_eid_records.hpp
@@ -24,6 +24,12 @@ class GuardWithoutEidRecords
     ~GuardWithoutEidRecords() = delete;
 
   public:
+    /** @brief Get count of guard records without associated error log objects
+     *
+     *  @param[in] guardRecords - Guard records
+     */
+    static int getCount(GuardRecords& guardRecords);
+
     /** @brief Captured deconfig data in NAG JSON file
      *
      *  @param[in] guardRecords - Guard records

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -1,0 +1,57 @@
+cpp = meson.get_compiler('cpp')
+
+sdbusplus_dep = dependency(
+    'sdbusplus',
+    fallback: ['sdbusplus', 'sdbusplus_dep'],
+)
+
+phosphor_dbus_interfaces_dep = dependency(
+    'phosphor-dbus-interfaces',
+    fallback: [
+        'phosphor-dbus-interfaces',
+        'phosphor_dbus_interfaces_dep'
+    ],  
+)
+
+phosphor_logging_dep = dependency(
+    'phosphor-logging',
+    fallback: ['phosphor-logging', 'phosphor_logging_dep'],
+)
+
+if cpp.has_header('nlohmann/json.hpp')
+    nlohmann_json = declare_dependency()
+else
+    nlohmann_json_proj = subproject('nlohmann', required: true)
+    nlohmann_json = nlohmann_json_proj.get_variable('nlohmann_json_dep')
+    nlohmann_json = nlohmann_json.as_system('system')
+endif
+
+libpdbg = meson.get_compiler('c').find_library('libpdbg')
+libdtapi = dependency('libdt-api')
+libguard = cpp.find_library('libguard')
+
+systemd_dep = dependency('systemd')
+
+faultlog_sources = [ 
+        'faultlog_main.cpp',
+        'guard_with_eid_records.cpp',
+        'util.cpp',
+        ]
+
+faultlog_dependencies = [ 
+        format,
+        phosphor_dbus_interfaces,
+        phosphor_logging,
+        sdbusplus,
+        nlohmann_json,
+        libpdbg,
+        libdtapi,
+        libguard
+    ]
+
+executable('faultlog',
+           faultlog_sources,
+           dependencies: faultlog_dependencies,
+           install : true
+          )
+

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -37,7 +37,8 @@ faultlog_sources = [
         'guard_with_eid_records.cpp',
         'util.cpp',
         'guard_without_eid_records.cpp',
-        'faultlog_policy.cpp'
+        'faultlog_policy.cpp',
+        'unresolved_pels.cpp'
         ]
 
 faultlog_dependencies = [ 

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -36,7 +36,8 @@ faultlog_sources = [
         'faultlog_main.cpp',
         'guard_with_eid_records.cpp',
         'util.cpp',
-        'guard_without_eid_records.cpp'
+        'guard_without_eid_records.cpp',
+        'faultlog_policy.cpp'
         ]
 
 faultlog_dependencies = [ 

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -36,6 +36,7 @@ faultlog_sources = [
         'faultlog_main.cpp',
         'guard_with_eid_records.cpp',
         'util.cpp',
+        'guard_without_eid_records.cpp'
         ]
 
 faultlog_dependencies = [ 

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -60,3 +60,4 @@ executable('faultlog',
            install : true
           )
 
+subdir('service')

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -38,7 +38,9 @@ faultlog_sources = [
         'util.cpp',
         'guard_without_eid_records.cpp',
         'faultlog_policy.cpp',
-        'unresolved_pels.cpp'
+        'unresolved_pels.cpp',
+        'deconfig_records.cpp',
+        'deconfig_reason.cpp'
         ]
 
 faultlog_dependencies = [ 

--- a/src/faultlog/service/faultlog_bmcboot.service.in
+++ b/src/faultlog/service/faultlog_bmcboot.service.in
@@ -1,0 +1,23 @@
+[Unit]
+Description=Faultlog application
+
+Wants=mapper-wait@-xyz-openbmc_project-inventory.service
+After=mapper-wait@-xyz-openbmc_project-inventory.service
+Wants=org.open_power.HardwareIsolation.service
+After=org.open_power.HardwareIsolation.service
+Wants=mapper-wait@-xyz-openbmc_project-logging.service
+After=mapper-wait@-xyz-openbmc_project-logging.service
+Wants=com.ibm.VPD.Manager.service
+After=com.ibm.VPD.Manager.service
+
+Wants=obmc-power-on@%0.target
+After=obmc-power-on@%0.target
+Conflicts=obmc-power-off@%0.target
+
+[Service]
+ExecStart=@bindir@/faultlog -c
+Type=oneshot
+SyslogIdentifier=faultlog
+
+[Install]
+WantedBy=multi-user.target

--- a/src/faultlog/service/faultlog_hostpoweron.service.in
+++ b/src/faultlog/service/faultlog_hostpoweron.service.in
@@ -1,0 +1,23 @@
+[Unit]
+Description=Faultlog application
+Wants=xyz.openbmc_project.Dump.Manager.service
+After=xyz.openbmc_project.Dump.Manager.service
+Wants=mapper-wait@-xyz-openbmc_project-inventory.service
+After=mapper-wait@-xyz-openbmc_project-inventory.service
+Wants=org.open_power.HardwareIsolation.service
+After=org.open_power.HardwareIsolation.service
+Wants=mapper-wait@-xyz-openbmc_project-logging.service
+After=mapper-wait@-xyz-openbmc_project-logging.service
+Wants=com.ibm.VPD.Manager.service
+After=com.ibm.VPD.Manager.service
+
+Wants=obmc-host-started@%0.target
+After=obmc-host-started@%0.target
+
+[Service]
+ExecStart=@bindir@/faultlog -c
+Type=oneshot
+SyslogIdentifier=faultlog
+
+[Install]
+WantedBy=obmc-host-startmin@0.target

--- a/src/faultlog/service/faultlog_periodic.timer
+++ b/src/faultlog/service/faultlog_periodic.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic faultlog timer to run once every month
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1mon
+Unit=faultlog_bmcboot.service
+
+[Install]
+WantedBy=timers.target

--- a/src/faultlog/service/meson.build
+++ b/src/faultlog/service/meson.build
@@ -1,0 +1,57 @@
+systemd_system_unit_dir = systemd_dep.get_variable(
+    pkgconfig:'systemdsystemunitdir')
+conf_data = configuration_data()
+conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
+
+input_files = ['faultlog_bmcboot.service.in', 'faultlog_hostpoweron.service.in',
+        'faultlog_periodic.timer']
+
+output_files = ['faultlog_bmcboot.service', 'faultlog_hostpoweron.service',
+        'faultlog_periodic.timer']
+
+counter = 0
+foreach i : input_files
+  # Get the index of the current iteration
+
+  # Configure the files using configure_file()
+  configure_file(
+    input : i,
+    output : output_files[counter],
+    configuration: conf_data,
+    install: true,
+    install_dir: systemd_system_unit_dir
+  )
+  counter += 1
+endforeach
+    
+systemd_alias = [[
+    '../faultlog_bmcboot.service', 'multi-user.target.wants/faultlog_bmcboot.service'
+]]
+
+systemd_alias += [[
+    '../faultlog_hostpoweron.service', 'obmc-host-startmin@0.target.wants/faultlog_hostpoweron.service'
+]]
+
+systemd_alias += [[
+    '../faultlog_periodic.timer', 'timers.target.wants/faultlog_periodic.timer'
+]]
+
+foreach service: systemd_alias
+    # Meson 0.61 will support this:
+    #install_symlink(
+    #      service,
+    #      install_dir: systemd_system_unit_dir,
+    #      pointing_to: link,
+    #  )
+    meson.add_install_script(
+        'sh', '-c',
+        'mkdir -p $(dirname $DESTDIR/@0@/@1@)'.format(systemd_system_unit_dir,
+            service[1]),
+    )   
+    meson.add_install_script(
+        'sh', '-c',
+        'ln -s @0@ $DESTDIR/@1@/@2@'.format(service[0], systemd_system_unit_dir,
+            service[1]),
+    )   
+endforeach
+

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -1,0 +1,245 @@
+#include <attributes_info.H>
+
+#include <libguard/guard_interface.hpp>
+#include <phosphor-logging/log.hpp>
+#include <unresolved_pels.hpp>
+#include <util.hpp>
+
+extern "C"
+{
+#include <libpdbg.h>
+}
+
+namespace openpower::faultlog
+{
+using ::nlohmann::json;
+
+using PropertyValue =
+    std::variant<std::string, bool, uint8_t, int16_t, uint16_t, int32_t,
+                 uint32_t, int64_t, uint64_t, double>;
+
+using Properties = std::map<std::string, PropertyValue>;
+
+using Interfaces = std::map<std::string, Properties>;
+
+using Objects = std::map<sdbusplus::message::object_path, Interfaces>;
+
+constexpr auto stateConfigured = "CONFIGURED";
+constexpr auto stateDeconfigured = "DECONFIGURED";
+
+struct GuardedTarget
+{
+    pdbg_target* target = nullptr;
+    std::string phyDevPath;
+    GuardedTarget(const std::string& path) : phyDevPath(path)
+    {}
+};
+
+static int getGuardedTarget(struct pdbg_target* target, void* priv)
+{
+    // recursive callback function that exits when the target matching the
+    // guarded targets physical path is found in the device tree.
+    // to exit the recursive function return 1 to continue return 0
+    GuardedTarget* guardTarget = reinterpret_cast<GuardedTarget*>(priv);
+    ATTR_PHYS_DEV_PATH_Type phyPath;
+    if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, phyPath))
+    {
+        if (strcmp(phyPath, guardTarget->phyDevPath.c_str()) == 0)
+        {
+            guardTarget->target = target;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
+                              GuardRecords& guardRecords, json& jsonNag)
+{
+    try
+    {
+        Objects objects;
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+        auto reply = bus.call(method);
+        reply.read(objects);
+        for (const auto& [path, interfaces] : objects)
+        {
+            bool resolved = true;
+            uint32_t id = 0;
+            std::string severity =
+                "xyz.openbmc_project.Logging.Entry.Level.Informational";
+            for (const auto& [intf, properties] : interfaces)
+            {
+                if (intf != "xyz.openbmc_project.Logging.Entry")
+                {
+                    continue;
+                }
+                for (const auto& [prop, propValue] : properties)
+                {
+                    if (prop == "Id")
+                    {
+                        auto idPtr = std::get_if<uint32_t>(&propValue);
+                        if (idPtr != nullptr)
+                        {
+                            id = *idPtr;
+                        }
+                    }
+                    else if (prop == "Resolved")
+                    {
+                        auto resolvedPtr = std::get_if<bool>(&propValue);
+                        if (resolvedPtr != nullptr)
+                        {
+                            resolved = *resolvedPtr;
+                        }
+                    }
+                    else if (prop == "Severity")
+                    {
+                        auto severityPtr = std::get_if<std::string>(&propValue);
+                        if (severityPtr != nullptr)
+                        {
+                            severity = *severityPtr;
+                        }
+                    }
+                }
+                break;
+            }
+            if (resolved == true)
+            {
+                continue;
+            }
+
+            // ignore informational and debug errors
+            if ((severity == "xyz.openbmc_project.Logging.Entry.Level.Debug") ||
+                (severity ==
+                 "xyz.openbmc_project.Logging.Entry.Level.Informational") ||
+                (severity == "xyz.openbmc_project.Logging.Entry.Level.Notice"))
+            {
+                continue;
+            }
+
+            // get pel json file
+            std::string pel;
+            auto method2 = bus.new_method_call(
+                "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+                "org.open_power.Logging.PEL", "GetPELJSON");
+            method2.append(id);
+            auto resp2 = bus.call(method2);
+            resp2.read(pel);
+            json pelJson = std::move(json::parse(pel));
+
+            // add cec errorlog
+            json jsonErrorLog = json::object();
+            jsonErrorLog["Callout Section"] =
+                pelJson["Primary SRC"]["Callout Section"];
+            bool deconfigured = false;
+            json& primarySRC = pelJson["Primary SRC"];
+            if (primarySRC.contains("Deconfigured") &&
+                !primarySRC["Deconfigured"].is_null())
+            {
+                if (primarySRC["Deconfigured"] == "True")
+                {
+                    deconfigured = true;
+                }
+            }
+            if (deconfigured == false)
+            {
+                continue;
+            }
+
+            bool guarded = false;
+            if (primarySRC.contains("Guarded") &&
+                !primarySRC["Guarded"].is_null())
+            {
+                if (primarySRC["Guarded"] == "True")
+                {
+                    guarded = true;
+                }
+            }
+            if (guarded == true)
+            {
+                continue; // will be captured as part of guard records
+            }
+
+            jsonErrorLog["ERR_PLID"] =
+                pelJson["Private Header"]["Platform Log Id"];
+            jsonErrorLog["Callout Section"] =
+                pelJson["Primary SRC"]["Callout Section"];
+            jsonErrorLog["SRC"] = pelJson["Primary SRC"]["Reference Code"];
+            jsonErrorLog["DATE_TIME"] = pelJson["Private Header"]["Created at"];
+
+            json jsonErrorLogSection = json::array();
+            jsonErrorLogSection.push_back(std::move(jsonErrorLog));
+
+            std::string bmcLogIdStr =
+                pelJson["Private Header"]["Platform Log Id"];
+            uint32_t bmcLogId =
+                static_cast<uint32_t>(std::stoul(bmcLogIdStr, nullptr, 16));
+
+            // add resource action check if guard record is found
+            json jsonResource = json::object();
+            for (const auto& elem : guardRecords)
+            {
+                if (elem.elogId == bmcLogId)
+                {
+                    auto physicalPath =
+                        openpower::guard::getPhysicalPath(elem.targetId);
+                    GuardedTarget guardedTarget(*physicalPath);
+                    pdbg_target_traverse(nullptr, getGuardedTarget,
+                                         &guardedTarget);
+                    if (guardedTarget.target == nullptr)
+                    {
+                        lg2::info("Failed to find the pdbg target for guarded "
+                                  "target {RECORD_ID}",
+                                  "RECORD_ID", elem.recordId);
+                        continue;
+                    }
+                    jsonResource["TYPE"] =
+                        pdbg_target_name(guardedTarget.target);
+                    std::string state = stateDeconfigured;
+                    ATTR_HWAS_STATE_Type hwasState;
+                    if (!DT_GET_PROP(ATTR_HWAS_STATE, guardedTarget.target,
+                                     hwasState))
+                    {
+                        if (hwasState.functional)
+                        {
+                            state = stateConfigured;
+                        }
+                    }
+                    jsonResource["CURRENT_STATE"] = std::move(state);
+
+                    ATTR_LOCATION_CODE_Type attrLocCode;
+                    if (!DT_GET_PROP(ATTR_LOCATION_CODE, guardedTarget.target,
+                                     attrLocCode))
+                    {
+                        jsonResource["LOCATION_CODE"] = attrLocCode;
+                    }
+
+                    jsonResource["REASON_DESCRIPTION"] =
+                        getGuardReason(guardRecords, *physicalPath);
+
+                    jsonResource["GARD_RECORD"] = true;
+
+                    break;
+                }
+            } // endfor
+            json jsonEventData = json::object();
+            jsonEventData["RESOURCE_ACTIONS"] = std::move(jsonResource);
+            jsonErrorLogSection.push_back(jsonEventData);
+
+            json jsonErrlogObj = json::object();
+            jsonErrlogObj["CEC_ERROR_LOG"] = std::move(jsonErrorLogSection);
+            json jsonServiceEvent = json::object();
+            jsonServiceEvent["SERVICABLE_EVENT"] = std::move(jsonErrlogObj);
+            jsonNag.push_back(std::move(jsonServiceEvent));
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error(
+            "Failed to add unresolved pels with deconfig bit set {ERROR}",
+            "ERROR", ex.what());
+    }
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/unresolved_pels.hpp
+++ b/src/faultlog/unresolved_pels.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <libguard/include/guard_record.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/bus.hpp>
+
+namespace openpower::faultlog
+{
+using ::openpower::guard::GuardRecords;
+
+/**
+ * @class UnresolvedPELs
+ *
+ *  Captures all unresolved PELS with deconfig/guard bit set
+ */
+class UnresolvedPELs
+{
+  private:
+    UnresolvedPELs() = delete;
+    UnresolvedPELs(const UnresolvedPELs&) = delete;
+    UnresolvedPELs& operator=(const UnresolvedPELs&) = delete;
+    UnresolvedPELs(UnresolvedPELs&&) = delete;
+    UnresolvedPELs& operator=(UnresolvedPELs&&) = delete;
+    ~UnresolvedPELs() = delete;
+
+  public:
+    /** @brief Populate unresolved PEL's serviceable events to NAG json
+     *
+     *  @param[in] bus - D-Bus to attach to
+     *  @param[in] guardRecords - hardware isolated records to parse
+     *  @param[in/out] jsonNag - Json file capturing serviceable events
+     */
+    static void populate(sdbusplus::bus::bus& bus, GuardRecords& guardRecords,
+                         nlohmann::json& jsonNag);
+};
+} // namespace openpower::faultlog

--- a/src/faultlog/unresolved_pels.hpp
+++ b/src/faultlog/unresolved_pels.hpp
@@ -24,13 +24,21 @@ class UnresolvedPELs
     ~UnresolvedPELs() = delete;
 
   public:
+    /** @brief Get count of unresolved pels with deconfig bit set
+     *  @param[in] bus - D-Bus to attach to
+     *
+     *  @return 0 if no records are found else count of records
+     */
+    static int getCount(sdbusplus::bus::bus& bus);
+
     /** @brief Populate unresolved PEL's serviceable events to NAG json
      *
      *  @param[in] bus - D-Bus to attach to
      *  @param[in] guardRecords - hardware isolated records to parse
      *  @param[in/out] jsonNag - Json file capturing serviceable events
      */
-    static void populate(sdbusplus::bus::bus& bus, GuardRecords& guardRecords,
+    static void populate(sdbusplus::bus::bus& bus,
+                         const GuardRecords& guardRecords,
                          nlohmann::json& jsonNag);
 };
 } // namespace openpower::faultlog

--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -1,0 +1,26 @@
+#include <libguard/guard_interface.hpp>
+#include <util.hpp>
+
+namespace openpower::faultlog
+{
+std::string getGuardReason(const GuardRecords& guardRecords,
+                           const std::string& path)
+{
+    for (const auto& elem : guardRecords)
+    {
+        auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
+        if (!physicalPath.has_value())
+        {
+            lg2::error("Failed to get physical path for record {RECORD_ID}",
+                       "RECORD_ID", elem.recordId);
+            continue;
+        }
+        std::string temp(*physicalPath);
+        if (temp.find(path) != std::string::npos)
+        {
+            return openpower::guard::guardReasonToStr(elem.errType);
+        }
+    }
+    return "Unknown";
+}
+} // namespace openpower::faultlog

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -43,6 +43,14 @@ T readProperty(sdbusplus::bus::bus& bus, const std::string& service,
     return retVal;
 }
 
+/**
+ * @brief get the guard reason for the specified physical path
+ *        of the pdbg target
+ * @param[in] guardRecords - guard records
+ * @param[in] path - physical path of the pdbg target
+ *
+ * @return guard reason stored as part of the guard record
+ */
 std::string getGuardReason(const GuardRecords& guardRecords,
                            const std::string& path);
 

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <libguard/include/guard_record.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+using ::openpower::guard::GuardRecords;
+
+namespace openpower::faultlog
+{
+
+/**
+ * @brief Read property value from the specified object and interface
+ * @param[in] bus D-Bus handle
+ * @param[in] service service which has implemented the interface
+ * @param[in] object object having has implemented the interface
+ * @param[in] intf interface having the property
+ * @param[in] prop name of the property to read
+ * @return property value
+ */
+template <typename T>
+T readProperty(sdbusplus::bus::bus& bus, const std::string& service,
+               const std::string& object, const std::string& intf,
+               const std::string& prop)
+{
+    T retVal{};
+    try
+    {
+        auto properties =
+            bus.new_method_call(service.c_str(), object.c_str(),
+                                "org.freedesktop.DBus.Properties", "Get");
+        properties.append(intf);
+        properties.append(prop);
+        auto result = bus.call(properties);
+        result.read(retVal);
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error(
+            "Failed to read property: {PROPERTY}, {INTF}, {PATH}, {ERROR}",
+            "PROPERTY", prop, "INTF", intf, "PATH", object, "ERROR", ex.what());
+        throw;
+    }
+    return retVal;
+}
+
+std::string getGuardReason(const GuardRecords& guardRecords,
+                           const std::string& path);
+
+} // namespace openpower::faultlog

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,1 @@
+subdir('faultlog')


### PR DESCRIPTION
Capture isolated/deconfigured/filedcodeoverride targets in JSON file, so that the records can be generated periodically or during poweron/reipl/failure to remind the customers or service engineers about the presence of failed parts in the system.

In certain situations, the service engineer or customer can defer the service action for some of the failures. In such cases,
there are chances to miss such failure records, and the system may fail unexpectedly, causing undesirable impacts. 

This problem is overcome by sending periodic error events to remind about the failed parts present in the system.

A new type of BMC dump will be added to capture failure data in JSON file and add to the dump.

This dump will be invoked during Power on, after repair and verify or periodically once a month, after a BMC failover or a BMC reboot from runtime.