### PR TITLE
nag : additional requirement for faultlog

### DIFF
--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -26,7 +26,7 @@ struct DeconfigDataList
 };
 
 /**
- * @brief Get pedgt targets which has been deconfigured
+ * @brief Get pdbg targets which has been deconfigured
  *
  * This callback function is called as part of the recursive method
  * pdbg_target_traverse, recursion will exit when the method return 1

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -56,7 +56,7 @@ void createNagPel(sdbusplus::bus::bus& bus,
             "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
             "xyz.openbmc_project.Logging.Create", "Create");
         method.append("org.open_power.Faultlog.Error.DeconfiguredHW",
-                      Severity::Error, data);
+                      Severity::Warning, data);
         auto reply = method.call();
         if (reply.is_method_error())
         {

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -31,13 +31,14 @@ using PropVariant = sdbusplus::utility::dedup_variant_t<Binary>;
  *
  *  @param[in] bus - D-Bus to attach to
  *  @param[in] guardRecords - hardware isolated records to parse
+ *  @param[in] hostPowerOn - flag to check if called during host IPL
  */
 void createNagPel(sdbusplus::bus::bus& bus,
-                  const GuardRecords& unresolvedRecords)
+                  const GuardRecords& unresolvedRecords, bool hostPowerOn)
 {
     int guardCount = GuardWithEidRecords::getCount(unresolvedRecords);
     int manualGuardCount = GuardWithoutEidRecords::getCount(unresolvedRecords);
-    int unresolvedPelsCount = UnresolvedPELs::getCount(bus);
+    int unresolvedPelsCount = UnresolvedPELs::getCount(bus, hostPowerOn);
     int deconfigCount = DeconfigRecords::getCount();
 
     if ((guardCount > 0) || (manualGuardCount > 0) ||
@@ -78,10 +79,11 @@ void createNagPel(sdbusplus::bus::bus& bus,
  *
  *  @param[in] bus - D-Bus to attach to
  *  @param[in] unresolvedRecords - hardware isolated records to parse
+ *  @param[in] hostPowerOn - flag to check if called during host IPL
  *  @param[in] msg - property change D-Bus message
  */
 void propertyChanged(sdbusplus::bus::bus& bus,
-                     const GuardRecords& unresolvedRecords,
+                     const GuardRecords& unresolvedRecords, bool hostPowerOn,
                      const sdbusplus::message::message& msg)
 {
     using ProgressStages = sdbusplus::xyz::openbmc_project::State::Boot::
@@ -111,7 +113,7 @@ void propertyChanged(sdbusplus::bus::bus& bus,
                 {
                     lg2::info("faultlog - host poweron host reached "
                               "apply guard state creating nag pel");
-                    createNagPel(bus, unresolvedRecords);
+                    createNagPel(bus, unresolvedRecords, hostPowerOn);
                     exit(EXIT_SUCCESS);
                 }
             }
@@ -241,7 +243,7 @@ int main(int argc, char** argv)
         // unresolved pels with deconfig bit set
         else if (unresolvedPels)
         {
-            (void)UnresolvedPELs::populate(bus, unresolvedRecords,
+            (void)UnresolvedPELs::populate(bus, unresolvedRecords, hostPowerOn,
                                            faultLogJson);
         }
 
@@ -254,7 +256,7 @@ int main(int argc, char** argv)
         // create fault log pel if there are service actions pending
         else if (createPel)
         {
-            createNagPel(bus, unresolvedRecords);
+            createNagPel(bus, unresolvedRecords, hostPowerOn);
         }
         // create bmc reboot pel
         else if (bmcReboot)
@@ -273,14 +275,14 @@ int main(int argc, char** argv)
             }
             else
             {
-                createNagPel(bus, unresolvedRecords);
+                createNagPel(bus, unresolvedRecords, hostPowerOn);
             }
         }
         else if (hostPowerOn)
         {
             if (isHostProgressStateRunning(bus))
             {
-                createNagPel(bus, unresolvedRecords);
+                createNagPel(bus, unresolvedRecords, hostPowerOn);
             }
             else
             {
@@ -293,8 +295,9 @@ int main(int argc, char** argv)
                             "/xyz/openbmc_project/state/host0",
                             "xyz.openbmc_project.State.Boot."
                             "Progress"),
-                        [&bus, &unresolvedRecords](auto& msg) {
-                            propertyChanged(bus, unresolvedRecords, msg);
+                        [&bus, &unresolvedRecords, hostPowerOn](auto& msg) {
+                            propertyChanged(bus, unresolvedRecords, hostPowerOn,
+                                            msg);
                         });
                 bus.process_loop();
             }
@@ -309,7 +312,7 @@ int main(int argc, char** argv)
 
             (void)FaultLogPolicy::populate(bus, faultLogJson);
 
-            (void)UnresolvedPELs::populate(bus, unresolvedRecords,
+            (void)UnresolvedPELs::populate(bus, unresolvedRecords, hostPowerOn,
                                            faultLogJson);
             (void)DeconfigRecords::populate(faultLogJson);
         }

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -1,4 +1,5 @@
 #include "xyz/openbmc_project/Logging/Entry/server.hpp"
+
 #include <CLI/CLI.hpp>
 #include <deconfig_records.hpp>
 #include <faultlog_policy.hpp>
@@ -25,6 +26,54 @@ using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
 
 using Binary = std::vector<uint8_t>;
 using PropVariant = sdbusplus::utility::dedup_variant_t<Binary>;
+
+/** @brief Helper method to create faultlog pel
+ *
+ *  @param[in] bus - D-Bus to attach to
+ *  @param[in] guardRecords - hardware isolated records to parse
+ */
+void createNagPel(sdbusplus::bus::bus& bus,
+                  const GuardRecords& unresolvedRecords)
+{
+    int guardCount = GuardWithEidRecords::getCount(unresolvedRecords);
+    int manualGuardCount = GuardWithoutEidRecords::getCount(unresolvedRecords);
+    int unresolvedPelsCount = UnresolvedPELs::getCount(bus);
+    int deconfigCount = DeconfigRecords::getCount();
+
+    if ((guardCount > 0) || (manualGuardCount > 0) ||
+        (unresolvedPelsCount > 0) || (deconfigCount > 0))
+    {
+        std::unordered_map<std::string, std::string> data = {
+            {"GUARD_WITH_ASSOC_ERROR_COUNT", std::to_string(guardCount)},
+            {"GUARD_WITH_NO_ASSOC_ERROR_COUNT",
+             std::to_string(manualGuardCount)},
+            {"UNRESOLVED_PEL_WITH_DECONFIG_BIT_COUNT",
+             std::to_string(unresolvedPelsCount)},
+            {"DECONFIG_RECORD_COUNT", std::to_string(deconfigCount)}};
+
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+            "xyz.openbmc_project.Logging.Create", "Create");
+        method.append("org.open_power.Faultlog.Error.DeconfiguredHW",
+                      Severity::Error, data);
+        auto reply = method.call();
+        if (reply.is_method_error())
+        {
+            lg2::error("Error in calling D-Bus method to create PEL");
+        }
+        lg2::info("faultlog {GUARD_COUNT}, {MAN_GUARD_COUNT}, "
+                  "{DECONFIG_COUNT} , {PEL_COUNT} ",
+                  "GUARD_COUNT", guardCount, "MAN_GUARD_COUNT",
+                  manualGuardCount, "DECONFIG_COUNT", deconfigCount,
+                  "PEL_COUNT", unresolvedPelsCount);
+    }
+    else
+    {
+        lg2::info("There are no pending service actions ignoring "
+                  "creating fautlog pel");
+    }
+}
+
 int main(int argc, char** argv)
 {
     try
@@ -84,6 +133,7 @@ int main(int argc, char** argv)
         bool deconfig = false;
         bool createPel = false;
         bool listFaultlog = false;
+        bool bmcReboot = false;
 
         app.set_help_flag("-h, --help", "Faultlog tool options");
         app.add_flag("-g, --guardwterr", guardWithEid,
@@ -101,6 +151,10 @@ int main(int argc, char** argv)
                      "Populate deconfigured target details to JSON");
         app.add_flag("-c, --createPel", createPel,
                      "Create faultlog pel if there are guarded/deconfigured "
+                     "records present");
+        app.add_flag("-r, --reboot", bmcReboot,
+                     "Create faultlog pel during reboot if there are "
+                     "guarded/deconfigured "
                      "records present");
         app.add_flag("-f, --faultlog", listFaultlog,
                      "List all fault log records in JSON format");
@@ -143,46 +197,26 @@ int main(int argc, char** argv)
         // create fault log pel if there are service actions pending
         else if (createPel)
         {
-            int guardCount = GuardWithEidRecords::getCount(unresolvedRecords);
-            int manualGuardCount =
-                GuardWithoutEidRecords::getCount(unresolvedRecords);
-            int unresolvedPelsCount = UnresolvedPELs::getCount(bus);
-            int deconfigCount = DeconfigRecords::getCount();
-
-            if ((guardCount > 0) || (manualGuardCount > 0) ||
-                (unresolvedPelsCount > 0) || (deconfigCount > 0))
+            createNagPel(bus, unresolvedRecords);
+        }
+        // create bmc reboot pel
+        else if (bmcReboot)
+        {
+            // interested only in bmc reboot, host should have been in IPL
+            // runtime during bmc reboot
+            if (!isHostStateRunning(bus)) // host started
             {
-                std::unordered_map<std::string, std::string> data;
-                data.emplace("GUARD_WITH_ASSOC_ERROR_COUNT",
-                             std::to_string(guardCount));
-                data.emplace("GUARD_WITH_NO_ASSOC_ERROR_COUNT",
-                             std::to_string(manualGuardCount));
-                data.emplace("UNRESOLVED_PEL_WITH_DECONFIG_BIT_COUNT",
-                             std::to_string(unresolvedPelsCount));
-                data.emplace("DECONFIG_RECORD_COUNT",
-                             std::to_string(deconfigCount));
+                lg2::info("Ignore, host is not started so not bmc reboot");
+            }
 
-                auto method = bus.new_method_call(
-                    "xyz.openbmc_project.Logging",
-                    "/xyz/openbmc_project/logging",
-                    "xyz.openbmc_project.Logging.Create", "Create");
-                method.append("org.open_power.Faultlog.Error.DeconfiguredHW",
-                              Severity::Error, data);
-                auto reply = method.call();
-                if (reply.is_method_error())
-                {
-                    lg2::error("Error in calling D-Bus method to create PEL");
-                }
-                lg2::info("faultlog {GUARD_COUNT}, {MAN_GUARD_COUNT}, "
-                          "{DECONFIG_COUNT} , {PEL_COUNT} ",
-                          "GUARD_COUNT", guardCount, "MAN_GUARD_COUNT",
-                          manualGuardCount, "DECONFIG_COUNT", deconfigCount,
-                          "PEL_COUNT", unresolvedPelsCount);
+            else if (!isHostProgressStateRunning(bus)) // host in ipl runtime
+            {
+                lg2::info(
+                    "Ignore, host is not in running state not bmc reboot");
             }
             else
             {
-                lg2::info("There are no pending service actions ignoring "
-                          "creating fautlog pel");
+                createNagPel(bus, unresolvedRecords);
             }
         }
         // write faultlog json to stdout

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -73,7 +73,7 @@ static int guardedTargets(struct pdbg_target* target, void* priv)
     return 0;
 }
 
-int GuardWithoutEidRecords::getCount(GuardRecords& guardRecords)
+int GuardWithoutEidRecords::getCount(const GuardRecords& guardRecords)
 {
     int count = 0;
     for (const auto& elem : guardRecords)

--- a/src/faultlog/guard_without_eid_records.hpp
+++ b/src/faultlog/guard_without_eid_records.hpp
@@ -28,7 +28,7 @@ class GuardWithoutEidRecords
      *
      *  @param[in] guardRecords - Guard records
      */
-    static int getCount(GuardRecords& guardRecords);
+    static int getCount(const GuardRecords& guardRecords);
 
     /** @brief Captured deconfig data in NAG JSON file
      *

--- a/src/faultlog/service/faultlog_bmcboot.service.in
+++ b/src/faultlog/service/faultlog_bmcboot.service.in
@@ -10,12 +10,13 @@ After=mapper-wait@-xyz-openbmc_project-logging.service
 Wants=com.ibm.VPD.Manager.service
 After=com.ibm.VPD.Manager.service
 
-Wants=obmc-power-on@%0.target
-After=obmc-power-on@%0.target
-Conflicts=obmc-power-off@%0.target
+Wants=obmc-power-on@0.target
+After=obmc-power-on@0.target
+Conflicts=obmc-power-off@0.target
+Conflicts=obmc-host-stop@0.target
 
 [Service]
-ExecStart=@bindir@/faultlog -c
+ExecStart=@bindir@/faultlog -r
 Type=oneshot
 SyslogIdentifier=faultlog
 

--- a/src/faultlog/service/faultlog_bmcboot.service.in
+++ b/src/faultlog/service/faultlog_bmcboot.service.in
@@ -10,8 +10,6 @@ After=mapper-wait@-xyz-openbmc_project-logging.service
 Wants=com.ibm.VPD.Manager.service
 After=com.ibm.VPD.Manager.service
 
-Wants=obmc-power-on@0.target
-After=obmc-power-on@0.target
 Conflicts=obmc-power-off@0.target
 Conflicts=obmc-host-stop@0.target
 

--- a/src/faultlog/service/faultlog_hostpoweron.service.in
+++ b/src/faultlog/service/faultlog_hostpoweron.service.in
@@ -11,11 +11,12 @@ After=mapper-wait@-xyz-openbmc_project-logging.service
 Wants=com.ibm.VPD.Manager.service
 After=com.ibm.VPD.Manager.service
 
-Wants=obmc-host-started@%0.target
-After=obmc-host-started@%0.target
+Wants=obmc-host-started@0.target
+After=obmc-host-started@0.target
+Conflicts=obmc-host-stop@0.target
 
 [Service]
-ExecStart=@bindir@/faultlog -c
+ExecStart=@bindir@/faultlog -p
 Type=oneshot
 SyslogIdentifier=faultlog
 

--- a/src/faultlog/service/faultlog_hostpoweron.service.in
+++ b/src/faultlog/service/faultlog_hostpoweron.service.in
@@ -21,4 +21,4 @@ Type=oneshot
 SyslogIdentifier=faultlog
 
 [Install]
-WantedBy=obmc-host-startmin@0.target
+#WantedBy=obmc-host-startmin@0.target

--- a/src/faultlog/service/faultlog_periodic.timer
+++ b/src/faultlog/service/faultlog_periodic.timer
@@ -2,8 +2,8 @@
 Description=Periodic faultlog timer to run once every month
 
 [Timer]
-OnBootSec=5min
-OnUnitActiveSec=1mon
+OnBootSec=30d
+OnUnitActiveSec=30d
 Unit=faultlog_bmcboot.service
 
 [Install]

--- a/src/faultlog/unresolved_pels.hpp
+++ b/src/faultlog/unresolved_pels.hpp
@@ -26,19 +26,23 @@ class UnresolvedPELs
   public:
     /** @brief Get count of unresolved pels with deconfig bit set
      *  @param[in] bus - D-Bus to attach to
+     *  @param[in] hostPowerOn - flag to specify if IPL is in progress
      *
      *  @return 0 if no records are found else count of records
      */
-    static int getCount(sdbusplus::bus::bus& bus);
+    static int getCount(sdbusplus::bus::bus& bus, bool hostPowerOn);
 
     /** @brief Populate unresolved PEL's serviceable events to NAG json
      *
      *  @param[in] bus - D-Bus to attach to
      *  @param[in] guardRecords - hardware isolated records to parse
+     *  @param[in] hostPowerOn - flag to specify if IPL is in progress
      *  @param[in/out] jsonNag - Json file capturing serviceable events
+     *
+     *  @return void
      */
     static void populate(sdbusplus::bus::bus& bus,
-                         const GuardRecords& guardRecords,
+                         const GuardRecords& guardRecords, bool hostPowerOn,
                          nlohmann::json& jsonNag);
 };
 } // namespace openpower::faultlog

--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -2,6 +2,9 @@
 #include <sdbusplus/exception.hpp>
 #include <util.hpp>
 
+#include <iomanip>
+#include <sstream>
+
 namespace openpower::faultlog
 {
 
@@ -100,6 +103,100 @@ bool isHostProgressStateRunning(sdbusplus::bus::bus& bus)
 bool isHostStateRunning(sdbusplus::bus::bus& bus)
 {
     return getHostState(bus) == HostState::Running;
+}
+
+std::string epochTimeToBCD(uint64_t milliSeconds)
+{
+    auto decimalToBCD = [](int value) {
+        std::stringstream ss;
+        ss << std::setw(2) << std::setfill('0') << value;
+        return ss.str();
+    };
+    std::chrono::milliseconds ms{milliSeconds};
+    std::chrono::time_point<std::chrono::system_clock> time{ms};
+
+    time_t t = std::chrono::system_clock::to_time_t(time);
+    tm* timeInfo = localtime(&t);
+
+    int year = 1900 + timeInfo->tm_year;
+    std::string bcdYear = decimalToBCD(year / 100);
+    bcdYear += decimalToBCD(year % 100);
+    std::string bcdMonth = decimalToBCD(timeInfo->tm_mon + 1); // Month (1-12)
+    std::string bcdDay = decimalToBCD(timeInfo->tm_mday);  // Day of the month
+    std::string bcdHour = decimalToBCD(timeInfo->tm_hour); // Hour (0-23)
+    std::string bcdMin = decimalToBCD(timeInfo->tm_min);   // Minutes
+    std::string bcdSec = decimalToBCD(timeInfo->tm_sec);   // Seconds
+
+    // Construct the BCD time string
+    //"DATE_TIME": "04/11/2023 09:39:15",
+    std::string bcdTime = bcdMonth + "/" + bcdDay + "/" + bcdYear + " " +
+                          bcdHour + ":" + bcdMin + ":" + bcdSec;
+    return bcdTime;
+}
+
+json parseCallout(const std::string callout)
+{
+    json callouthdrJson = json::object();
+    if (callout.empty())
+    {
+        return callouthdrJson;
+    }
+
+    // lambda method to split the string based on delimiter
+    auto splitString = [](const std::string& str, char delimiter) {
+        std::vector<std::string> tokens;
+        std::stringstream ss(str);
+        std::string token;
+
+        while (std::getline(ss, token, delimiter))
+        {
+            tokens.push_back(token);
+        }
+
+        return tokens;
+    };
+
+    std::vector<std::string> lines = splitString(callout, '\n');
+    json calloutsJson = json::array();
+
+    for (const auto& line : lines)
+    {
+        std::vector<std::string> tokens = splitString(line, ',');
+        json calloutJson = json::object();
+
+        for (const auto& token : tokens)
+        {
+            std::size_t colonPos = token.find(':');
+
+            if (colonPos != std::string::npos)
+            {
+                std::string key = token.substr(0, colonPos);
+                key.erase(0, key.find_first_not_of(' '));
+                key.erase(key.find_last_not_of(' ') + 1);
+                std::string value = token.substr(colonPos + 1);
+                value.erase(0, value.find_first_not_of(' '));
+                value.erase(value.find_last_not_of(' ') + 1);
+                if (key.find("Location Code") != std::string::npos)
+                {
+                    key = "Location Code";
+                }
+                else if (key.find("SN") != std::string::npos)
+                {
+                    key = "Serial Number";
+                }
+                else if (key.find("PN") != std::string::npos)
+                {
+                    key = "Part Number";
+                }
+                calloutJson[key] = value;
+            }
+        }
+        calloutsJson.push_back(calloutJson);
+    }
+    json sectionJson = json::object();
+    sectionJson["Callout Count"] = lines.size();
+    sectionJson["Callouts"] = calloutsJson;
+    return sectionJson;
 }
 
 } // namespace openpower::faultlog

--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -1,8 +1,15 @@
 #include <libguard/guard_interface.hpp>
+#include <sdbusplus/exception.hpp>
 #include <util.hpp>
 
 namespace openpower::faultlog
 {
+
+using ProgressStages = sdbusplus::xyz::openbmc_project::State::Boot::server::
+    Progress::ProgressStages;
+using HostState =
+    sdbusplus::xyz::openbmc_project::State::server::Host::HostState;
+
 std::string getGuardReason(const GuardRecords& guardRecords,
                            const std::string& path)
 {
@@ -23,4 +30,76 @@ std::string getGuardReason(const GuardRecords& guardRecords,
     }
     return "Unknown";
 }
+ProgressStages getBootProgress(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        using PropertiesVariant =
+            sdbusplus::utility::dedup_variant_t<ProgressStages>;
+
+        auto retVal = readProperty<PropertiesVariant>(
+            bus, "xyz.openbmc_project.State.Host",
+            "/xyz/openbmc_project/state/host0",
+            "xyz.openbmc_project.State.Boot.Progress", "BootProgress");
+        const ProgressStages* progPtr = std::get_if<ProgressStages>(&retVal);
+        if (progPtr != nullptr)
+        {
+            return *progPtr;
+        }
+    }
+    catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        lg2::error("Failed to read Boot Progress property {ERROR}", "ERROR",
+                   ex.what());
+    }
+
+    lg2::error("Failed to read Boot Progress state value");
+    return ProgressStages::Unspecified;
+}
+
+HostState getHostState(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        using PropertiesVariant =
+            sdbusplus::utility::dedup_variant_t<HostState>;
+
+        auto retVal = readProperty<PropertiesVariant>(
+            bus, "xyz.openbmc_project.State.Host",
+            "/xyz/openbmc_project/state/host0",
+            "xyz.openbmc_project.State.Host", "CurrentHostState");
+        const HostState* statePtr = std::get_if<HostState>(&retVal);
+        if (statePtr != nullptr)
+        {
+            return *statePtr;
+        }
+    }
+    catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        lg2::error("Failed to read host state property {ERROR}", "ERROR",
+                   ex.what());
+    }
+
+    lg2::error("Failed to read host state value");
+    return HostState::Off;
+}
+
+bool isHostProgressStateRunning(sdbusplus::bus::bus& bus)
+{
+    ProgressStages progress = getBootProgress(bus);
+    if ((progress == ProgressStages::SystemInitComplete) ||
+        (progress == ProgressStages::SystemSetup) ||
+        (progress == ProgressStages::OSStart) ||
+        (progress == ProgressStages::OSRunning))
+    {
+        return true;
+    }
+    return false;
+}
+
+bool isHostStateRunning(sdbusplus::bus::bus& bus)
+{
+    return getHostState(bus) == HostState::Running;
+}
+
 } // namespace openpower::faultlog

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -3,6 +3,8 @@
 #include <libguard/include/guard_record.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/State/Boot/Progress/server.hpp>
+#include <xyz/openbmc_project/State/Host/server.hpp>
 using ::openpower::guard::GuardRecords;
 
 namespace openpower::faultlog
@@ -53,5 +55,21 @@ T readProperty(sdbusplus::bus::bus& bus, const std::string& service,
  */
 std::string getGuardReason(const GuardRecords& guardRecords,
                            const std::string& path);
+
+/**
+ * @brief Return true if host completed IPL and reached runtime
+ * @param[in] bus - D-Bus handle
+ *
+ * @return true if in runtime else false
+ */
+bool isHostProgressStateRunning(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Return true if host started running
+ * @param[in] bus - D-Bus handle
+ *
+ * @return true if host started
+ */
+bool isHostStateRunning(sdbusplus::bus::bus& bus);
 
 } // namespace openpower::faultlog

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
 #include <libguard/include/guard_record.hpp>
+#include <nlohmann/json.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/server.hpp>
 #include <xyz/openbmc_project/State/Host/server.hpp>
-using ::openpower::guard::GuardRecords;
+
+#include <ctime>
 
 namespace openpower::faultlog
 {
-
+using ::nlohmann::json;
+using ::openpower::guard::GuardRecords;
 /**
  * @brief Read property value from the specified object and interface
  * @param[in] bus D-Bus handle
@@ -71,4 +74,22 @@ bool isHostProgressStateRunning(sdbusplus::bus::bus& bus);
  * @return true if host started
  */
 bool isHostStateRunning(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Return time in BCD from milliSeconds since epoch time
+ * @param[in] milliSeconds - milli seconds since epoch time
+ *
+ * @return string time value in string format
+ */
+std::string epochTimeToBCD(uint64_t milliSeconds);
+
+/**
+ * @brief Parse the callout values from the logging Resolution property
+ *
+ * @param[in] callout - callouts string
+ *
+ * @return Json object as per NAG specification for callouts
+ */
+json parseCallout(const std::string callout);
+
 } // namespace openpower::faultlog

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -71,5 +71,4 @@ bool isHostProgressStateRunning(sdbusplus::bus::bus& bus);
  * @return true if host started
  */
 bool isHostStateRunning(sdbusplus::bus::bus& bus);
-
 } // namespace openpower::faultlog


### PR DESCRIPTION
1) Ensure that only one instance of faultlog application invoked as part of different services runs at a time, other service needs to be terminated
2) Ensure that during host poweron wait for host to apply guard records as part of IPL before collecting faultlog data. Using temporary daemon for it.
3) Read data from the newly added properties to the logging D-Bus interface rather than reading the data by loading the PEL json file as it is time consuming process.