### PR TITLE
nag : fix issues noticed during self test and defects

### DIFF
--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -60,10 +60,6 @@ static int getDeconfigTargets(struct pdbg_target* target, void* priv)
                 }
                 default:
                 {
-                    lg2::info(
-                        "Ignoring deconfig target {TARGET} {DECONFIG_EID} ",
-                        "TARGET", pdbg_target_name(target), "DECONFIG_EID",
-                        static_cast<int>(hwasState.deconfiguredByEid));
                     break;
                 }
             }

--- a/src/faultlog/deconfig_records.hpp
+++ b/src/faultlog/deconfig_records.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <libguard/include/guard_record.hpp>
 #include <nlohmann/json.hpp>
 
 namespace openpower::faultlog
 {
+using ::openpower::guard::GuardRecords;
 /**
  * @class DeconfigRecords
  *
@@ -26,13 +28,18 @@ class DeconfigRecords
     /** @brief Get deconfigured records count by parsing through pdbg targets
      *
      *  @return 0 if no records are found else count of records
+     *  @param[in] guardRecords - list of guarded targets to ignore as part of
+     * parsing
      */
-    static int getCount();
+    static int getCount(const GuardRecords& guardRecords);
 
     /** @brief Populate target details that have deconfiguredByEid set
      *
-     *  @param[in] jsonNag - Update JSON deconfigure records
+     *  @param[in] guardRecords - list of guarded targets to ignore as part of
+     *  @param[inout] jsonNag - Update JSON deconfigure records
+     * parsing
      */
-    static void populate(nlohmann::json& jsonNag);
+    static void populate(const GuardRecords& guardRecords,
+                         nlohmann::json& jsonNag);
 };
 } // namespace openpower::faultlog

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -305,13 +305,11 @@ int main(int argc, char** argv)
         // write faultlog json to stdout
         else if (listFaultlog)
         {
+            (void)FaultLogPolicy::populate(bus, faultLogJson);
             (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
                                                 faultLogJson);
             (void)GuardWithoutEidRecords::populate(unresolvedRecords,
                                                    faultLogJson);
-
-            (void)FaultLogPolicy::populate(bus, faultLogJson);
-
             (void)UnresolvedPELs::populate(bus, unresolvedRecords, hostPowerOn,
                                            faultLogJson);
             (void)DeconfigRecords::populate(faultLogJson);

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -40,17 +40,21 @@ void createNagPel(sdbusplus::bus::bus& bus,
     int manualGuardCount = GuardWithoutEidRecords::getCount(unresolvedRecords);
     int unresolvedPelsCount = UnresolvedPELs::getCount(bus, hostPowerOn);
     int deconfigCount = DeconfigRecords::getCount();
+    lg2::info(
+        "faultlog GUARD_COUNT: {GUARD_COUNT}, MAN_GUARD_COUNT: "
+        "{MAN_GUARD_COUNT}, "
+        "DECONFIG_REC_COUNT: {DECONFIG_REC_COUNT} , PEL_COUNT: {PEL_COUNT} ",
+        "GUARD_COUNT", guardCount, "MAN_GUARD_COUNT", manualGuardCount,
+        "DECONFIG_REC_COUNT", deconfigCount, "PEL_COUNT", unresolvedPelsCount);
 
-    if ((guardCount > 0) || (manualGuardCount > 0) ||
-        (unresolvedPelsCount > 0) || (deconfigCount > 0))
+    // create pels only for system guard and serviceable events and not for
+    // manual guard or FCO
+    if ((guardCount > 0) || (unresolvedPelsCount > 0))
     {
         std::unordered_map<std::string, std::string> data = {
-            {"GUARD_WITH_ASSOC_ERROR_COUNT", std::to_string(guardCount)},
-            {"GUARD_WITH_NO_ASSOC_ERROR_COUNT",
-             std::to_string(manualGuardCount)},
-            {"UNRESOLVED_PEL_WITH_DECONFIG_BIT_COUNT",
-             std::to_string(unresolvedPelsCount)},
-            {"DECONFIG_RECORD_COUNT", std::to_string(deconfigCount)}};
+            {"GUARD_RECORD_COUNT", std::to_string(guardCount)},
+            {"PEL_WITH_DECONFIG_BIT_COUNT",
+             std::to_string(unresolvedPelsCount)}};
 
         auto method = bus.new_method_call(
             "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
@@ -62,11 +66,6 @@ void createNagPel(sdbusplus::bus::bus& bus,
         {
             lg2::error("Error in calling D-Bus method to create PEL");
         }
-        lg2::info("faultlog {GUARD_COUNT}, {MAN_GUARD_COUNT}, "
-                  "{DECONFIG_COUNT} , {PEL_COUNT} ",
-                  "GUARD_COUNT", guardCount, "MAN_GUARD_COUNT",
-                  manualGuardCount, "DECONFIG_COUNT", deconfigCount,
-                  "PEL_COUNT", unresolvedPelsCount);
     }
     else
     {

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -36,10 +36,15 @@ using PropVariant = sdbusplus::utility::dedup_variant_t<Binary>;
 void createNagPel(sdbusplus::bus::bus& bus,
                   const GuardRecords& unresolvedRecords, bool hostPowerOn)
 {
+    //
+    // serviceable records count
     int guardCount = GuardWithEidRecords::getCount(unresolvedRecords);
-    int manualGuardCount = GuardWithoutEidRecords::getCount(unresolvedRecords);
     int unresolvedPelsCount = UnresolvedPELs::getCount(bus, hostPowerOn);
-    int deconfigCount = DeconfigRecords::getCount();
+
+    //
+    // deconfigured records count
+    int manualGuardCount = GuardWithoutEidRecords::getCount(unresolvedRecords);
+    int deconfigCount = DeconfigRecords::getCount(unresolvedRecords);
     lg2::info(
         "faultlog GUARD_COUNT: {GUARD_COUNT}, MAN_GUARD_COUNT: "
         "{MAN_GUARD_COUNT}, "
@@ -249,7 +254,7 @@ int main(int argc, char** argv)
         // pdbg targets with deconfig bit set
         else if (deconfig)
         {
-            (void)DeconfigRecords::populate(faultLogJson);
+            (void)DeconfigRecords::populate(unresolvedRecords, faultLogJson);
         }
 
         // create fault log pel if there are service actions pending
@@ -305,13 +310,17 @@ int main(int argc, char** argv)
         else if (listFaultlog)
         {
             (void)FaultLogPolicy::populate(bus, faultLogJson);
+            // serviceable event records
             (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
                                                 faultLogJson);
-            (void)GuardWithoutEidRecords::populate(unresolvedRecords,
-                                                   faultLogJson);
             (void)UnresolvedPELs::populate(bus, unresolvedRecords, hostPowerOn,
                                            faultLogJson);
-            (void)DeconfigRecords::populate(faultLogJson);
+
+            //
+            // deconfigured records count
+            (void)GuardWithoutEidRecords::populate(unresolvedRecords,
+                                                   faultLogJson);
+            (void)DeconfigRecords::populate(unresolvedRecords, faultLogJson);
         }
         else
         {

--- a/src/faultlog/faultlog_policy.cpp
+++ b/src/faultlog/faultlog_policy.cpp
@@ -1,5 +1,5 @@
-#include <phosphor-logging/lg2.hpp>
 #include <faultlog_policy.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <util.hpp>
 
 namespace openpower::faultlog
@@ -44,8 +44,8 @@ void FaultLogPolicy::populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson)
         }
         catch (const std::exception& ex)
         {
-            lg2::error("Failed to read allow_hw_isolation property {ERROR}",
-                       "ERROR", ex.what());
+            lg2::info("Failed to read allow_hw_isolation property {ERROR}",
+                      "ERROR", ex);
         }
         jsonPolicyVal["MASTER"] = enabled;
 
@@ -60,7 +60,7 @@ void FaultLogPolicy::populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson)
     catch (const std::exception& ex)
     {
         lg2::error("Failed to add isolation policy details to JSON {ERROR}",
-                   "ERROR", ex.what());
+                   "ERROR", ex);
     }
 
     return;

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -4,7 +4,6 @@
 #include <libguard/guard_interface.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <util.hpp>
-#include <xyz/openbmc_project/Common/error.hpp>
 
 extern "C"
 {
@@ -26,7 +25,7 @@ struct GuardedTarget
     GuardedTarget(const std::string& path) : phyDevPath(path)
     {}
 };
-using ::sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+
 using PropertyValue =
     std::variant<std::string, bool, uint8_t, int16_t, uint16_t, int32_t,
                  uint32_t, int64_t, uint64_t, double>;
@@ -231,7 +230,7 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             jsonServiceEvent["SERVICABLE_EVENT"] = std::move(jsonErrlogObj);
             jsonNag.push_back(std::move(jsonServiceEvent));
         }
-        catch (const InvalidArgument& ex)
+        catch (const sdbusplus::exception::SdBusError& ex)
         {
             lg2::info(
                 "PEL might be deleted but guard entry is around {ELOG_ID)",

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -193,7 +193,10 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                 continue;
             }
             json jsonResource = json::object();
-            jsonResource["TYPE"] = pdbg_target_name(guardedTarget.target);
+            if (pdbg_target_name(guardedTarget.target) != nullptr)
+            {
+                jsonResource["TYPE"] = pdbg_target_name(guardedTarget.target);
+            }
             std::string state = stateDeconfigured;
             ATTR_HWAS_STATE_Type hwasState;
             if (!DT_GET_PROP(ATTR_HWAS_STATE, guardedTarget.target, hwasState))

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -168,7 +168,6 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                 ss << std::hex << "0x" << plid;
                 jsonErrorLog["ERR_PLID"] = ss.str();
                 jsonErrorLog["Callout Section"] = parseCallout(callouts);
-                refCode.insert(0, "0x");
                 jsonErrorLog["SRC"] = refCode;
                 jsonErrorLog["DATE_TIME"] = epochTimeToBCD(timestamp);
             }

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -140,8 +140,9 @@ void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
                 {
                     state = stateConfigured;
                 }
-                deconfigJson["PLID"] =
-                    std::to_string(hwasState.deconfiguredByEid);
+                std::stringstream ss;
+                ss << std::hex << "0x" << hwasState.deconfiguredByEid;
+                deconfigJson["PLID"] = ss.str();
             }
             deconfigJson["CURRENT_STATE"] = std::move(state);
 

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -4,7 +4,6 @@
 #include <phosphor-logging/log.hpp>
 #include <unresolved_pels.hpp>
 #include <util.hpp>
-#include <xyz/openbmc_project/Common/error.hpp>
 
 extern "C"
 {
@@ -275,18 +274,18 @@ int UnresolvedPELs::getCount(sdbusplus::bus::bus& bus, bool hostPowerOn)
             count += 1;
         } // endfor
     }
-    catch (
-        const sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument&
-            ex)
+    catch (const sdbusplus::exception::SdBusError& ex)
     {
-        lg2::info("PEL might be deleted but entry is around {ERROR}", "ERROR",
-                  ex.what());
+        lg2::info("There are no PELS or PEL corresponding to guard record is "
+                  "deleted "
+                  " {ERROR}",
+                  "ERROR", ex);
     }
     catch (const std::exception& ex)
     {
         lg2::error("Failed to get count of unresolved pels with deconfig bit "
                    "set {ERROR}",
-                   "ERROR", ex.what());
+                   "ERROR", ex);
     }
     return count;
 }
@@ -521,18 +520,18 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
             jsonNag.push_back(std::move(jsonServiceEvent));
         }
     }
-    catch (
-        const sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument&
-            ex)
+    catch (const sdbusplus::exception::SdBusError& ex)
     {
-        lg2::info("PEL might be deleted but entry is around {ERROR}", "ERROR",
-                  ex.what());
+        lg2::info("There are no PELS or PEL corresponding to guard record is "
+                  "deleted "
+                  " {ERROR}",
+                  "ERROR", ex);
     }
     catch (const std::exception& ex)
     {
         lg2::error("Failed to add unresolved pels with deconfig bit "
                    "set {ERROR}",
-                   "ERROR", ex.what());
+                   "ERROR", ex);
     }
 }
 } // namespace openpower::faultlog

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -451,7 +451,7 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
             // add cec errorlog
             json jsonErrorLog = json::object();
             std::stringstream ss;
-            ss << std::hex << plid;
+            ss << std::hex << "0x" << plid;
             jsonErrorLog["ERR_PLID"] = ss.str();
             jsonErrorLog["Callout Section"] = parseCallout(callouts);
             refCode.insert(0, "0x");

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -454,7 +454,6 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
             ss << std::hex << "0x" << plid;
             jsonErrorLog["ERR_PLID"] = ss.str();
             jsonErrorLog["Callout Section"] = parseCallout(callouts);
-            refCode.insert(0, "0x");
             jsonErrorLog["SRC"] = refCode;
             jsonErrorLog["DATE_TIME"] = epochTimeToBCD(timestamp);
 

--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -136,10 +136,9 @@ std::string epochTimeToBCD(uint64_t milliSeconds)
 
 json parseCallout(const std::string callout)
 {
-    json callouthdrJson = json::object();
     if (callout.empty())
     {
-        return callouthdrJson;
+        return json::object();
     }
 
     // lambda method to split the string based on delimiter


### PR DESCRIPTION
Fix some of the issues noticed related to traces, and formatting, noticed during self-test

1) Validate pdbg target properties before accessing them
2) Use SdBusErrror exception class for any errors thrown as part of D-Bus calls.
3) Consistently log PLID in hexa decimal format
4) If PEL's are deleted for a guard record created with error injection add what ever data available rather than ignoring the guard record.

Change-Id: I081221b85f34638a77817c8b3e10a2cc37d0ec76