### PR TITLE
nag: change hostpoweron service to type simple

### DIFF
--- a/src/faultlog/service/faultlog_hostpoweron.service.in
+++ b/src/faultlog/service/faultlog_hostpoweron.service.in
@@ -17,7 +17,7 @@ Conflicts=obmc-host-stop@0.target
 
 [Service]
 ExecStart=@bindir@/faultlog -p
-Type=oneshot
+Type=simple
 SyslogIdentifier=faultlog
 
 [Install]


### PR DESCRIPTION
As host poweron service waits for host to reach runtime, it cannot be a oneshot service, changed service type to simple.


Change-Id: I6d49178e3b35656cd4a00459eaeac6df68dd2b91