### PR TITLE
nag : fix faultlog defects

### DIFF
--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -57,6 +57,7 @@ faultlog_dependencies = [
 executable('faultlog',
            faultlog_sources,
            dependencies: faultlog_dependencies,
+           include_directories: include_directories('../../'),
            install : true
           )
 


### PR DESCRIPTION
During BMC reboot with host in running state noticed guard records are not captured as part of the faultlog JSON file.

Found during BMC reboot when host is at runing pdbg device tree is not initialized so was not able to read the properties of the guarded targets.

Current error:
Jul 03 08:40:21 rain104bmc faultlog[822]: Failed to get physical path for record 1

Tested:
Jul 03 10:20:29 rain104bmc systemd[1]: Started Faultlog application. Jul 03 10:20:29 rain104bmc faultlog[2437]: faultlog app to collect deconfig/guard records details Jul 03 10:20:30 rain104bmc faultlog[2437]: faultlog GUARD_COUNT: 1, MAN_GUARD_COUNT: 1, DECONFIG_REC_COUNT: 0 , PEL_COUNT: 0