### PR TITLE
nag: Fix PLID of deconfig records showing incorrect value

### DIFF
--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -140,9 +140,8 @@ void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
                 {
                     state = stateConfigured;
                 }
-                std::stringstream ss;
-                ss << std::hex << "0x" << hwasState.deconfiguredByEid;
-                deconfigJson["PLID"] = ss.str();
+                // Manually deconfigured records will not have a PLID
+                deconfigJson["PLID"] = 0x0;
             }
             deconfigJson["CURRENT_STATE"] = std::move(state);
 


### PR DESCRIPTION
For manually deconfigured records set the value to 0x0

 Tested
 before
 {
     "DECONFIGURED": {
     "CURRENT_STATE": "DECONFIGURED",
     "LOCATION_CODE": "Ufcs-P0-C15",
     "PHYS_PATH": "physical:sys-0/node-0/proc-1",
     "PLID": "0xff01",
     "REASON_DESCRIPTION": "manual",
     "TYPE": "Processor Module"
    }
  }
 after
 {
     "DECONFIGURED": {
     "CURRENT_STATE": "DECONFIGURED",
     "LOCATION_CODE": "Ufcs-P0-C15",
     "PHYS_PATH": "physical:sys-0/node-0/proc-1",
     "PLID": 0,
     "REASON_DESCRIPTION": "manual",
     "TYPE": "Processor Module"
    }
 }

Signed-off-by: Gopichand Paturi  <gopichandpaturi@gmail.com>
Change-Id: If90887fda605e6475890807f72ac43681ea7f407