### PR TITLE
nag: Rename "ERR_PLID" to "PLID" to maintain consistency

### DIFF
--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -172,7 +172,7 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                 }
                 std::stringstream ss;
                 ss << std::hex << "0x" << plid;
-                jsonErrorLog["ERR_PLID"] = ss.str();
+                jsonErrorLog["PLID"] = ss.str();
                 jsonErrorLog["Callout Section"] = parseCallout(callouts);
                 jsonErrorLog["SRC"] = refCode;
                 jsonErrorLog["DATE_TIME"] = epochTimeToBCD(timestamp);
@@ -231,7 +231,7 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                     sectionJson["Callout Count"] = 1;
                 }
                 sectionJson["Callouts"] = jsonCallout;
-                jsonErrorLog["ERR_PLID"] =
+                jsonErrorLog["PLID"] =
                     std::to_string(hwasState.deconfiguredByEid);
                 jsonErrorLog["Callout Section"] = sectionJson;
                 jsonErrorLog["SRC"] = 0;

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -459,7 +459,7 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
             json jsonErrorLog = json::object();
             std::stringstream ss;
             ss << std::hex << "0x" << plid;
-            jsonErrorLog["ERR_PLID"] = ss.str();
+            jsonErrorLog["PLID"] = ss.str();
             jsonErrorLog["Callout Section"] = parseCallout(callouts);
             jsonErrorLog["SRC"] = refCode;
             jsonErrorLog["DATE_TIME"] = epochTimeToBCD(timestamp);


### PR DESCRIPTION
nag: Rename "ERR_PLID" to "PLID" to maintain consistency
       Under CEC ERROR LOG, Error Log Id is denoted as ERR_PLID and other places it is denoted as PLID. To maintain 
consistency it is renamed to "PLID"

      Before:
      "CEC_ERROR_LOG": [
        {
          "Callout Section": {},
          "DATE_TIME": "07/25/2023 06:23:21",
          "ERR_PLID": "0x0", ---> Not consistent
          "SRC": "BD60280E"
        },

       Test Results:
      "CEC_ERROR_LOG": [
        {
          "Callout Section": {},
          "DATE_TIME": "07/25/2023 06:44:41",
          "PLID": "0x50000d86", ---> updated to PLID
          "SRC": "BD60280E"
        },
Signed-off-by: Parasa Swetha <Parasa.Swetha1@ibm.com>
Change-Id: Ide71b8d0587eca212a982200d021300b3bb4ee24