### PR TITLE
nag : fix periodic service fail during boot

### DIFF
--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -31,7 +31,6 @@ using ::openpower::guard::GuardRecords;
 using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
 
 using Binary = std::vector<uint8_t>;
-using PropVariant = sdbusplus::utility::dedup_variant_t<Binary>;
 
 /**
  * @brief To init phal library for use power system specific device tree
@@ -183,16 +182,13 @@ int main(int argc, char** argv)
         std::string propVal{};
         try
         {
-            auto retVal = readProperty<PropVariant>(
+            auto pVal = readProperty<Binary>(
                 bus, "xyz.openbmc_project.Inventory.Manager",
                 "/xyz/openbmc_project/inventory/system/chassis/"
                 "motherboard",
                 "com.ibm.ipzvpd.VSYS", "TM");
-            if (auto pVal = std::get_if<Binary>(&retVal))
-            {
-                propVal.assign(reinterpret_cast<const char*>(pVal->data()),
-                               pVal->size());
-            }
+            propVal.assign(reinterpret_cast<const char*>(pVal.data()),
+                           pVal.size());
         }
         catch (const std::exception& ex)
         {

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -176,9 +176,6 @@ int main(int argc, char** argv)
         CLI::App app{"Faultlog tool"};
         app.set_help_flag("-h, --help", "Faultlog tool options");
 
-        initPHAL();
-        openpower::guard::libguard_init(false);
-
         auto bus = sdbusplus::bus::new_default();
 
         nlohmann::json faultLogJson = json::array();
@@ -207,20 +204,6 @@ int main(int argc, char** argv)
         nlohmann::json systemHdr;
         systemHdr["SYSTEM"] = std::move(system);
         faultLogJson.push_back(systemHdr);
-
-        // Don't get ephemeral records because those type records are
-        // not intended to expose to the end user, just created for
-        // internal purpose to use by the BMC and Hostboot.
-        openpower::guard::GuardRecords records = openpower::guard::getAll(true);
-        GuardRecords unresolvedRecords;
-        // filter out all unused or resolved records
-        for (const auto& elem : records)
-        {
-            if (elem.recordId != GUARD_RESOLVED)
-            {
-                unresolvedRecords.emplace_back(elem);
-            }
-        }
 
         bool guardWithEid = false;
         bool guardWithoutEid = false;
@@ -262,8 +245,43 @@ int main(int argc, char** argv)
 
         CLI11_PARSE(app, argc, argv);
 
+        // create bmc reboot pel
+        if (bmcReboot)
+        {
+            // interested only in bmc reboot, host should have been in
+            // IPL runtime during bmc reboot
+            if (!isHostProgressStateRunning(bus)) // host in ipl runtime
+            {
+                lg2::info("Ignore, host is not in running state not "
+                          "bmc reboot");
+                exit(EXIT_SUCCESS);
+            }
+        }
+
+        initPHAL();
+        openpower::guard::libguard_init(false);
+
+        // Don't get ephemeral records because those type records are
+        // not intended to expose to the end user, just created for
+        // internal purpose to use by the BMC and Hostboot.
+        openpower::guard::GuardRecords records = openpower::guard::getAll(true);
+        GuardRecords unresolvedRecords;
+        // filter out all unused or resolved records
+        for (const auto& elem : records)
+        {
+            if (elem.recordId != GUARD_RESOLVED)
+            {
+                unresolvedRecords.emplace_back(elem);
+            }
+        }
+
+        // host will be already on, create nagpel
+        if (bmcReboot)
+        {
+            createNagPel(bus, unresolvedRecords, hostPowerOn);
+        }
         // guard records with associated error object
-        if (guardWithEid)
+        else if (guardWithEid)
         {
             (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
                                                 faultLogJson);
@@ -299,26 +317,6 @@ int main(int argc, char** argv)
         else if (createPel)
         {
             createNagPel(bus, unresolvedRecords, hostPowerOn);
-        }
-        // create bmc reboot pel
-        else if (bmcReboot)
-        {
-            // interested only in bmc reboot, host should have been in
-            // IPL runtime during bmc reboot
-            if (!isHostStateRunning(bus)) // host started
-            {
-                lg2::info("Ignore, host is not started so not bmc reboot");
-            }
-
-            else if (!isHostProgressStateRunning(bus)) // host in ipl runtime
-            {
-                lg2::info("Ignore, host is not in running state not "
-                          "bmc reboot");
-            }
-            else
-            {
-                createNagPel(bus, unresolvedRecords, hostPowerOn);
-            }
         }
         else if (hostPowerOn)
         {

--- a/src/faultlog/service/faultlog_periodic.service.in
+++ b/src/faultlog/service/faultlog_periodic.service.in
@@ -1,5 +1,7 @@
 [Unit]
-Description=Faultlog application
+Description=Faultlog application (periodic)
+ConditionPathExists=/var/lib/phosphor-software-manager/hostfw/running/DEVTREE
+ConditionPathExists=/var/lib/phosphor-software-manager/hostfw/running/GUARD
 
 [Service]
 ExecStart=@bindir@/faultlog -r

--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -37,18 +37,10 @@ ProgressStages getBootProgress(sdbusplus::bus::bus& bus)
 {
     try
     {
-        using PropertiesVariant =
-            sdbusplus::utility::dedup_variant_t<ProgressStages>;
-
-        auto retVal = readProperty<PropertiesVariant>(
+        return readProperty<ProgressStages>(
             bus, "xyz.openbmc_project.State.Host",
             "/xyz/openbmc_project/state/host0",
             "xyz.openbmc_project.State.Boot.Progress", "BootProgress");
-        const ProgressStages* progPtr = std::get_if<ProgressStages>(&retVal);
-        if (progPtr != nullptr)
-        {
-            return *progPtr;
-        }
     }
     catch (const sdbusplus::exception::SdBusError& ex)
     {
@@ -64,18 +56,10 @@ HostState getHostState(sdbusplus::bus::bus& bus)
 {
     try
     {
-        using PropertiesVariant =
-            sdbusplus::utility::dedup_variant_t<HostState>;
-
-        auto retVal = readProperty<PropertiesVariant>(
-            bus, "xyz.openbmc_project.State.Host",
-            "/xyz/openbmc_project/state/host0",
-            "xyz.openbmc_project.State.Host", "CurrentHostState");
-        const HostState* statePtr = std::get_if<HostState>(&retVal);
-        if (statePtr != nullptr)
-        {
-            return *statePtr;
-        }
+        return readProperty<HostState>(bus, "xyz.openbmc_project.State.Host",
+                                       "/xyz/openbmc_project/state/host0",
+                                       "xyz.openbmc_project.State.Host",
+                                       "CurrentHostState");
     }
     catch (const sdbusplus::exception::SdBusError& ex)
     {


### PR DESCRIPTION
Now periodic service is invoked as part of the initial systemd services.

As guard, device tree are not initialized yet faultlog application fails during startup.

Now modifid to exit early if in case the host is not in running state yet before checking for guard records and e.t.c.

Also adding condition path check on device tree and guard mount path to exit early if in case the service is executed before the device tree and guard are mounted.

Tested:
root@p10bmc:~# systemctl status faultlog_periodic.service
* faultlog_periodic.service - Faultlog application (periodic) Loaded: loaded (/lib/systemd/system/faultlog_periodic.service; static) Active: inactive (dead) TriggeredBy: * faultlog_periodic.timer
  Condition: start condition failed at Mon 2023-07-31 01:10:03 UTC; 2min 15s ago `- ConditionPathExists=/var/lib/phosphor-software-manager/hostfw/running/GUARD was not met

Jul 31 01:10:03 p10bmc systemd[1]: Faultlog application (periodic) was skipped because of an unmet condition check (ConditionPathExists=/var/lib/phosphor-software-manager/ho...running/GUARD)

root@p10bmc:~# systemctl status faultlog_periodic.service
* faultlog_periodic.service - Faultlog application (periodic) Loaded: loaded (/lib/systemd/system/faultlog_periodic.service; static) Active: inactive (dead) since Mon 2023-07-31 01:14:27 UTC; 7s ago TriggeredBy: * faultlog_periodic.timer
    Process: 2081 ExecStart=/usr/bin/faultlog -r (code=exited, status=0/SUCCESS)
   Main PID: 2081 (code=exited, status=0/SUCCESS)
        CPU: 34ms

Jul 31 01:14:27 p10bmc systemd[1]: Starting Faultlog application (periodic)...
Jul 31 01:14:27 p10bmc faultlog[2081]: faultlog app to collect deconfig/guard records details
Jul 31 01:14:27 p10bmc systemd[1]: faultlog_periodic.service: Deactivated successfully.
Jul 31 01:14:27 p10bmc systemd[1]: Finished Faultlog application (periodic).


Change-Id: I80de903c07211518f54ff64c22c0166920d9ab50