### PR TITLE
nag: get location code from parent if not found in target

### DIFF
--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -1,11 +1,11 @@
 #include <attributes_info.H>
+#include <libphal.H>
 
 #include <deconfig_reason.hpp>
 #include <deconfig_records.hpp>
 #include <libguard/guard_interface.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <util.hpp>
-
 namespace openpower::faultlog
 {
 
@@ -144,11 +144,11 @@ void DeconfigRecords::populate(const GuardRecords& guardRecords,
                 continue;
             }
 
-            ATTR_LOCATION_CODE_Type attrLocCode;
-            if (!DT_GET_PROP(ATTR_LOCATION_CODE, target, attrLocCode))
-            {
-                deconfigJson["LOCATION_CODE"] = attrLocCode;
-            }
+            // getLocationCode checks if attr is present in target else
+            // gets it from partent target
+            ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+            openpower::phal::pdbg::getLocationCode(target, attrLocCode);
+            deconfigJson["LOCATION_CODE"] = attrLocCode;
 
             json header = json::object();
             header["DECONFIGURED"] = std::move(deconfigJson);

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -1,4 +1,5 @@
 #include <attributes_info.H>
+#include <libphal.H>
 
 #include <guard_with_eid_records.hpp>
 #include <libguard/guard_interface.hpp>
@@ -9,7 +10,6 @@ extern "C"
 {
 #include <libpdbg.h>
 }
-
 namespace openpower::faultlog
 {
 using ::nlohmann::json;
@@ -221,12 +221,14 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             {
                 json jsonCallout = json::object();
                 json sectionJson = json::object();
-                ATTR_LOCATION_CODE_Type attrLocCode;
-                if (!DT_GET_PROP(ATTR_LOCATION_CODE, guardedTarget.target,
-                                 attrLocCode))
-                {
-                    jsonCallout["Location Code"] = attrLocCode;
-                }
+
+                // getLocationCode checks if attr is present in target else
+                // gets it from partent target
+                ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+                openpower::phal::pdbg::getLocationCode(guardedTarget.target,
+                                                       attrLocCode);
+                jsonCallout["Location Code"] = attrLocCode;
+
                 sectionJson["Callout Count"] = 1;
                 sectionJson["Callouts"] = jsonCallout;
                 jsonErrorLog["PLID"] =

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -1,4 +1,5 @@
 #include <attributes_info.H>
+#include <libphal.H>
 
 #include <guard_without_eid_records.hpp>
 #include <libguard/guard_interface.hpp>
@@ -9,7 +10,6 @@ extern "C"
 {
 #include <libpdbg.h>
 }
-
 namespace openpower::faultlog
 {
 
@@ -154,11 +154,11 @@ void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
                 continue;
             }
 
-            ATTR_LOCATION_CODE_Type attrLocCode;
-            if (!DT_GET_PROP(ATTR_LOCATION_CODE, target, attrLocCode))
-            {
-                deconfigJson["LOCATION_CODE"] = attrLocCode;
-            }
+            // getLocationCode checks if attr is present in target else
+            // gets it from partent target
+            ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+            openpower::phal::pdbg::getLocationCode(target, attrLocCode);
+            deconfigJson["LOCATION_CODE"] = attrLocCode;
 
             json header = json::object();
             header["MANUAL_ISOLATION"] = std::move(deconfigJson);

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -29,6 +29,8 @@ endif
 libpdbg = meson.get_compiler('c').find_library('libpdbg')
 libdtapi = dependency('libdt-api')
 libguard = cpp.find_library('libguard')
+libphal = cpp.find_library('phal')
+
 
 systemd_dep = dependency('systemd')
 
@@ -52,6 +54,7 @@ faultlog_dependencies = [
         libpdbg,
         libdtapi,
         libguard,
+        libphal,
         sdeventplus
     ]
 

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -1,4 +1,5 @@
 #include <attributes_info.H>
+#include <libphal.H>
 
 #include <libguard/guard_interface.hpp>
 #include <phosphor-logging/log.hpp>
@@ -441,12 +442,12 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
                     }
                     jsonResource["CURRENT_STATE"] = std::move(state);
 
-                    ATTR_LOCATION_CODE_Type attrLocCode;
-                    if (!DT_GET_PROP(ATTR_LOCATION_CODE, guardedTarget.target,
-                                     attrLocCode))
-                    {
-                        jsonResource["LOCATION_CODE"] = attrLocCode;
-                    }
+                    // getLocationCode checks if attr is present in target else
+                    // gets it from partent target
+                    ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+                    openpower::phal::pdbg::getLocationCode(guardedTarget.target,
+                                                           attrLocCode);
+                    jsonResource["LOCATION_CODE"] = attrLocCode;
 
                     jsonResource["REASON_DESCRIPTION"] =
                         getGuardReason(guardRecords, *physicalPath);


### PR DESCRIPTION
Now using PHAL api which fetches LOCATOIN_CODE from parent if not found in the target.

Tested:
Before
  {
    "MANUAL_ISOLATION": {
      "CURRENT_STATE": "DECONFIGURED",
      "PHYS_PATH": "physical:sys-0/node-0/proc-3/mc-3/mi-0/mcc-0/omi-1",
      "REASON_DESCRIPTION": "manual",
      "TYPE": "POWER10 omi"
    }
  }

After
  {
    "DECONFIGURED": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C24",
      "PHYS_PATH": "physical:sys-0/node-0/proc-3/mc-3/mi-0/mcc-1/omi-1",
      "PLID": "0x90000cd1",
      "REASON_DESCRIPTION": "ERROR LOG",
      "TYPE": "POWER10 omi"
    }
  }


Change-Id: I46b81ffde394ae51528617f7145a7bbbd9226a3b