### PR TITLE
nag: Rename 'GARD_RECORD' to 'GUARD_RECORD'

### DIFF
--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -214,7 +214,7 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             jsonResource["REASON_DESCRIPTION"] =
                 getGuardReason(guardRecords, *physicalPath);
 
-            jsonResource["GARD_RECORD"] = true;
+            jsonResource["GUARD_RECORD"] = true;
 
             // error object is deleted add what ever data is found
             if (!dbusErrorObjFound)

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -452,7 +452,7 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
                     jsonResource["REASON_DESCRIPTION"] =
                         getGuardReason(guardRecords, *physicalPath);
 
-                    jsonResource["GARD_RECORD"] = true;
+                    jsonResource["GUARD_RECORD"] = true;
 
                     break;
                 }


### PR DESCRIPTION
The spelling of "Guard" has been written as "GARD" instead of "GUARD" in some places. Therefore, to maintain consistency, "GARD_RECORD" has been changed to "GUARD_RECORD"

    Before:
    "SERVICEABLE_EVENT": {
       "CEC_ERROR_LOG": [
        {
          "Callout Section": {
            "Callout Count": 2,
            "Callouts": [
              {
                "CCIN": "5C67",
                "Location Code": "U78DA.ND0.WZS004A-P0-C24",
                "Part Number": "F210110",
                "Priority": "Medium",
                "Serial Number": ""
              },
              {
                "2. Priority": "Medium",
                "Procedure": "BMC0004"
              }
            ]
          },
          "DATE_TIME": "09/27/2023 16:30:16",
          "PLID": "0x5000ff31",
          "SRC": "BD503001"
        },
        {
          "RESOURCE_ACTIONS": {
            "CURRENT_STATE": "DECONFIGURED",
            "GARD_RECORD": true,                        --> misspelt
            "REASON_DESCRIPTION": "PREDICTIVE",
            "TYPE": "Processor Module"
          }
        }
      ]
    }

    Test Results:
     "SERVICEABLE_EVENT": {
      "CEC_ERROR_LOG": [
        {
          "Callout Section": {
            "Callout Count": 2,
            "Callouts": [
              {
                "CCIN": "5C67",
                "Location Code": "U78DA.ND0.WZS004A-P0-C24",
                "Part Number": "F210110",
                "Priority": "Medium",
                "Serial Number": ""
              },
              {
                "2. Priority": "Medium",
                "Procedure": "BMC0004"
              }
            ]
          },
          "DATE_TIME": "09/27/2023 16:30:16",
          "PLID": "0x5000ff31",
          "SRC": "BD503001"
        },
        {
          "RESOURCE_ACTIONS": {
            "CURRENT_STATE": "DECONFIGURED",
            "GUARD_RECORD": true,                       --> changed to GUARD_RECORD
            "REASON_DESCRIPTION": "PREDICTIVE",
            "TYPE": "Processor Module"
          }
        }
      ]
    }

Change-Id: I30a89797c0b073be2663f9b7570f5a07eed63f08
Signed-off-by: Parasa Swetha <Parasa.Swetha1@ibm.com>