### PR TITLE
Remove SERVICEABLE_EVENT section if it is empty

### DIFF
--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -200,6 +200,22 @@ void propertyChanged(sdbusplus::bus::bus& bus, sdbusplus::message::message& msg,
     }
 }
 
+/** @brief Method to add SERVICEABLE_EVENT section in faultlog
+ *
+ *  @param[in] errorlog - Holds the list of errorlogs
+ *  @param[in] faultLogJson - Holds deconfig/guard record details
+ */
+void addServiceableEvents(const nlohmann::json& errorlog,
+                          nlohmann::json& faultLogJson)
+{
+    if (!errorlog.empty())
+    {
+        nlohmann::json jsonServiceEvent;
+        jsonServiceEvent["SERVICEABLE_EVENT"] = std::move(errorlog);
+        faultLogJson.emplace_back(jsonServiceEvent);
+    }
+}
+
 int main(int argc, char** argv)
 {
     try
@@ -304,9 +320,7 @@ int main(int argc, char** argv)
             nlohmann::json errorlog = json::array();
             (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
                                                 errorlog);
-            nlohmann::json jsonServiceEvent;
-            jsonServiceEvent["SERVICEABLE_EVENT"] = std::move(errorlog);
-            faultLogJson.emplace_back(jsonServiceEvent);
+            addServiceableEvents(errorlog, faultLogJson);
         }
 
         // guard records without any associated error object
@@ -328,9 +342,7 @@ int main(int argc, char** argv)
             // serviceable event records
             nlohmann::json errorlog = json::array();
             (void)UnresolvedPELs::populate(bus, unresolvedRecords, errorlog);
-            nlohmann::json jsonServiceEvent;
-            jsonServiceEvent["SERVICEABLE_EVENT"] = std::move(errorlog);
-            faultLogJson.emplace_back(jsonServiceEvent);
+            addServiceableEvents(errorlog, faultLogJson);
         }
 
         // pdbg targets with deconfig bit set
@@ -405,9 +417,7 @@ int main(int argc, char** argv)
             (void)GuardWithEidRecords::populate(bus, unresolvedRecords,
                                                 errorlog);
             (void)UnresolvedPELs::populate(bus, unresolvedRecords, errorlog);
-            nlohmann::json jsonServiceEvent;
-            jsonServiceEvent["SERVICEABLE_EVENT"] = std::move(errorlog);
-            faultLogJson.emplace_back(jsonServiceEvent);
+            addServiceableEvents(errorlog, faultLogJson);
 
             //
             // deconfigured records count


### PR DESCRIPTION
Even without guard records and pels, SERVICEABLE_EVENT is displayed in faultlog. Removing the SERVICEABLE_EVENT section if there is no data in it.

Before:
```
root@p10bmc:/tmp# guard -l
No Records to display
root@p10bmc:/tmp# peltool -l
{}
root@p10bmc:/tmp# faultlog -f
<6> faultlog app to collect deconfig/guard records details <6> Latest chassis poweron time read is :12/06/2023 06:39:33 [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22B"
    }
  },
  {
    "POLICY": {
      "FCO_VALUE": 0,
      "MASTER": true,
      "PREDICTIVE": true
    }
  },
  {
    "SERVICEABLE_EVENT": []  ----> It is displayed even if it is empty
  }
]
root@p10bmc:/tmp# faultlog -u
<6> faultlog app to collect deconfig/guard records details <6> Latest chassis poweron time read is :12/06/2023 06:39:33 [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22B"
    }
  },
  {
    "SERVICEABLE_EVENT": []  ----> It is displayed even if it is empty
  }
]
root@p10bmc:/tmp# faultlog -g
<6> faultlog app to collect deconfig/guard records details [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22B"
    }
  },
  {
    "SERVICEABLE_EVENT": []  ----> It is displayed even if it is empty
  }
]

```
Test Results:
```
root@p10bmc:/tmp/test# guard -l
No Records to display
root@p10bmc:/tmp/test# peltool -l
{}
root@p10bmc:/tmp/test# faultlog -f
<6> faultlog app to collect deconfig/guard records details <6> Latest chassis poweron time read is :12/06/2023 06:39:33 [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22B"
    }
  },
  {
    "POLICY": {
      "FCO_VALUE": 0,
      "MASTER": true,
      "PREDICTIVE": true
    }
  }
]
root@p10bmc:/tmp/test# faultlog -g
<6> faultlog app to collect deconfig/guard records details [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22B"
    }
  }
]
root@p10bmc:/tmp/test# faultlog -u
<6> faultlog app to collect deconfig/guard records details <6> Latest chassis poweron time read is :12/06/2023 06:39:33 [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22B"
    }
  }
]

```
Change-Id: Ifbf1704fbd0a87a2b7ca2615d471e559be9008f8
Signed-off-by: Parasa Swetha <Parasa.Swetha1@ibm.com>