### PR TITLE
nag: Add Physical Path of the target to Resource Actions section

### DIFF
--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -344,7 +344,11 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                 getGuardReason(guardRecords, *physicalPath);
 
             jsonResource["GUARD_RECORD"] = true;
-
+            ATTR_PHYS_DEV_PATH_Type phyPath;
+            if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, guardedTarget.target, phyPath))
+            {
+                jsonResource["PHYS_PATH"] = phyPath;
+            }
             // An error could create single PEL but multiple guard records,
             // while processing guard records do not create multiple error log
             // sections as the callout data retrieved from the PEL will be the

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -453,6 +453,12 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
                         getGuardReason(guardRecords, *physicalPath);
 
                     jsonResource["GUARD_RECORD"] = true;
+                    ATTR_PHYS_DEV_PATH_Type phyPath;
+                    if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, guardedTarget.target,
+                                     phyPath))
+                    {
+                        jsonResource["PHYS_PATH"] = phyPath;
+                    }
 
                     break;
                 }


### PR DESCRIPTION
Before:
```
 "SERVICEABLE_EVENT": [
      {
        "CEC_ERROR_LOG": [
          {
            "Callout Section": {},
            "DATE_TIME": "12/19/2023 10:34:13",
            "PLID": "0x500011a4",
            "SRC": "BD60280E"
          },
          {
            "RESOURCE_ACTIONS": {
              "CURRENT_STATE": "DECONFIGURED",
              "GUARD_RECORD": true,
              "REASON_DESCRIPTION": "PREDICTIVE",
              "TYPE": "POWER10 DIMM"
            }
          }
        ]
      }
    ]
```

Test Results:
```
 "SERVICEABLE_EVENT": [
      {
        "CEC_ERROR_LOG": [
          {
            "Callout Section": {},
            "DATE_TIME": "12/19/2023 10:34:13",
            "PLID": "0x500011a4",
            "SRC": "BD60280E"
          },
          {
            "RESOURCE_ACTIONS": {
              "CURRENT_STATE": "DECONFIGURED",
              "GUARD_RECORD": true,
              "PHYS_PATH": "physical:sys-0/node-0/dimm-34",             -----> Added PHYS_PATH field to RESOURCE_ACTIONS
              "REASON_DESCRIPTION": "PREDICTIVE",
              "TYPE": "POWER10 DIMM"
            }
          }
        ]
      }
    ]
```
Change-Id: I8f8527d0d434fee60e132417c8c2d5bd68fbe736
 Signed-off-by: SwethaParasa <parasa.swetha1@ibm.com>