### PR TITLE
nag: fix service file to remain after exit during warm reboot

### DIFF
--- a/src/faultlog/service/faultlog_create_chassis_poweron_time.service.in
+++ b/src/faultlog/service/faultlog_create_chassis_poweron_time.service.in
@@ -9,6 +9,7 @@ ConditionPathExists=!/run/openbmc/chassis@0-on
 [Service]
 Restart=no
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=@bindir@/faultlog-poweron-time
 
 [Install]


### PR DESCRIPTION
Existing faultlog chassis poweron timer systemd service writes the current time to a file and exits the service.

Expectation is that the faultlog chassis poweron systemd service is restarted only during chassis poweron.

Faultlog chassis poweron systemd service has a dependency on obmc poweron target.

Noticed during warm reboot all targets that have dependency and not running on obmc poweron target are started. As the faultlog timer service has exited it restarts it and it writes new time stamp to the file.

Application considers only those PELS that are created after the new chassis poweron time and missed PELS that caused reipl/warm reboot.

Now modified to let the service run till the chassis poweroff service is called.

Tested
Before:
Oct 16 04:42:51 rainjmt01bmc phosphor-log-manager[383]: Created PEL 0x500088f2 (BMC ID 1) with SRC BD8D3416 Oct 16 04:42:50 rainjmt01bmc faultlog-poweron-time[2047]: Latest chassis poweron time written is :10/16/2023 04:42:50 Oct 16 04:48:03 rainjmt01bmc faultlog-poweron-time[3475]: Latest chassis poweron time written is :10/16/2023 04:48:03

After:
Oct 25 20:56:34 p10bmc phosphor-log-manager[369]: Created PEL 0x500043be (BMC ID 138) with SRC BD8D3416 Oct 25 20:56:34 p10bmc faultlog-poweron-time[26694]: Latest chassis poweron time  written is :10/25/2023 20:56:34

Change-Id: Id83661b02158074a62380f7d5ea51c429d94b72b