### PR TITLE
common: Consider the last dimm as parent

### DIFF
--- a/src/common/isolatable_hardwares.cpp
+++ b/src/common/isolatable_hardwares.cpp
@@ -207,9 +207,10 @@ std::optional<
     IsolatableHWs::getIsotableHWDetails(
         const IsolatableHWs::HW_Details::HwId& id) const
 {
-    auto it = std::find_if(
-        _isolatableHWsList.begin(), _isolatableHWsList.end(),
-        [&id](const auto& isolatableHw) { return isolatableHw.first == id; });
+    auto it = std::find_if(_isolatableHWsList.begin(), _isolatableHWsList.end(),
+                           [&id](const auto& isolatableHw) {
+        return isolatableHw.first == id;
+    });
 
     if (it != _isolatableHWsList.end())
     {
@@ -665,16 +666,6 @@ std::optional<struct pdbg_target*>
                     .c_str());
             return std::nullopt;
         }
-        else if (dimmCount > 1)
-        {
-            log<level::ERR>(
-                std::format("More [{}] dimm targets are present "
-                            "in phal cec device tree for the given phal cec "
-                            " device tree target [{}]",
-                            dimmCount, fruUnitDevTreePath)
-                    .c_str());
-            return std::nullopt;
-        }
     }
     else
     {
@@ -742,7 +733,7 @@ std::optional<sdbusplus::message::object_path>
             inventoryPathList->begin(), inventoryPathList->end(),
             [&fruInstId, &fruInvPathLookupFunc, this](const auto& path) {
             return fruInvPathLookupFunc(this->_bus, path, fruInstId);
-        });
+            });
 
         if (fruHwInvPath == inventoryPathList->end())
         {
@@ -1046,7 +1037,7 @@ std::optional<sdbusplus::message::object_path> IsolatableHWs::getInventoryPath(
                  this](const auto& path) {
                 return isolatedHwDetails->second._invPathFuncLookUp(
                     this->_bus, path, uniqIsolateHwKey);
-            });
+                });
 
             if (isolateHwPath == childsInventoryPath->end())
             {

--- a/src/common/isolatable_hardwares.cpp
+++ b/src/common/isolatable_hardwares.cpp
@@ -207,10 +207,9 @@ std::optional<
     IsolatableHWs::getIsotableHWDetails(
         const IsolatableHWs::HW_Details::HwId& id) const
 {
-    auto it = std::find_if(_isolatableHWsList.begin(), _isolatableHWsList.end(),
-                           [&id](const auto& isolatableHw) {
-        return isolatableHw.first == id;
-    });
+    auto it = std::find_if(
+        _isolatableHWsList.begin(), _isolatableHWsList.end(),
+        [&id](const auto& isolatableHw) { return isolatableHw.first == id; });
 
     if (it != _isolatableHWsList.end())
     {
@@ -622,54 +621,83 @@ std::optional<struct pdbg_target*>
     std::string fruUnitDevTreePath{pdbg_target_path(devTreeTgt)};
     std::string fruUnitPdbgClass{pdbg_target_class_name(devTreeTgt)};
 
-    /**
-     * As we have more than one logical dimm under ocmb and ocmb has
-     * LocationCode Return the same target if it is a ocmb
-     */
-    if (fruUnitPdbgClass == "ocmb")
-        return devTreeTgt;
-
     struct pdbg_target* parentFruTarget = nullptr;
-    std::optional<std::pair<HW_Details::HwId, HW_Details>> parentFruHw =
-        getIsotableHWDetails(HW_Details::HwId(
-            HW_Details::HwId::PhalPdbgClassName(fruUnitPdbgClass)));
-
-    if (!parentFruHw.has_value())
-    {
-        log<level::ERR>(
-            std::format("Failed to get the parent target from phal cec "
-                        "device tree for the given target [{}]",
-                        fruUnitDevTreePath)
-                .c_str());
-        return std::nullopt;
-    }
-
-    std::string parentPdbgClass =
-        parentFruHw.value().second._parentFruHwId._pdbgClassName._name;
-    if (parentPdbgClass == "dimm")
+    if ((fruUnitPdbgClass == "ocmb") || (fruUnitPdbgClass == "mem_port") ||
+        (fruUnitPdbgClass == "adc") || (fruUnitPdbgClass == "gpio_expander") ||
+        (fruUnitPdbgClass == "pmic"))
     {
         /**
-         *  Earlier, the assumption was that dimm was parent of ocmb and
-         * mem_port ocmb was the parent for adc,pmic and gpio_expander We used
-         * to return the parent dimm for these targets But now we can have more
-         * than one logical dimm under a ocmb So We are returning parent ocmb to
-         * avoid confusion as LocationCode is available for ocmb target now.
+         * FIXME: The assumption is, dimm is parent fru for "ocmb", "mem_port",
+         *        "adc", "gpio_expander", and "pmic" units and those units
+         *        will have only one "dimm" so if something is changed then,
+         *        need to fix this logic.
+         * @note  In phal cec device tree dimm is placed under ocmb->mem_port
+         *        based on dimm pervasive path.
          */
-        parentPdbgClass = "ocmb";
-    }
+        if ((fruUnitPdbgClass == "adc") ||
+            (fruUnitPdbgClass == "gpio_expander") ||
+            (fruUnitPdbgClass == "pmic"))
+        {
+            /**
+             * The "adc", "gpio_expander", and "pmic" units are placed under
+             * ocmb but, dimm is placed under the ocmb so, we need to get the
+             * parent ocmb for the given "adc", "gpio_expander", and "pmic"
+             * units to get the dimm fru target.
+             */
+            devTreeTgt = pdbg_target_parent("ocmb", devTreeTgt);
+        }
 
-    parentFruTarget = pdbg_target_parent(parentPdbgClass.c_str(), devTreeTgt);
-    if (parentFruTarget == nullptr)
+        auto dimmCount = 0;
+        struct pdbg_target* lastDimmTgt = nullptr;
+        pdbg_for_each_target("dimm", devTreeTgt, lastDimmTgt)
+        {
+            parentFruTarget = lastDimmTgt;
+            ++dimmCount;
+        }
+
+        if (dimmCount == 0)
+        {
+            log<level::ERR>(
+                std::format("Failed to get the parent dimm target "
+                            "from phal cec device tree for the given phal cec "
+                            "device tree target [{}]",
+                            fruUnitDevTreePath)
+                    .c_str());
+            return std::nullopt;
+        }
+        else if (dimmCount > 1)
+        {
+            log<level::ERR>(
+                std::format("More [{}] dimm targets are present "
+                            "in phal cec device tree for the given phal cec "
+                            " device tree target [{}]",
+                            dimmCount, fruUnitDevTreePath)
+                    .c_str());
+            return std::nullopt;
+        }
+    }
+    else
     {
-        log<level::ERR>(
-            std::format("Failed to get the parent target from phal cec "
-                        "device tree for the given target [{}]",
-                        fruUnitDevTreePath)
-                .c_str());
-        return std::nullopt;
+        /**
+         * FIXME: Today, All FRU parts (units - both(chiplet and non-chiplet))
+         *        are modelled under the respective processor in cec device
+         *        tree so, if something changed then, need to revisit the
+         *        logic which is used to get the FRU details of FRU unit.
+         */
+        parentFruTarget = pdbg_target_parent("proc", devTreeTgt);
+        if (parentFruTarget == nullptr)
+        {
+            log<level::ERR>(
+                std::format("Failed to get the processor target from phal cec "
+                            "device tree for the given target [{}]",
+                            fruUnitDevTreePath)
+                    .c_str());
+            return std::nullopt;
+        }
     }
     return parentFruTarget;
 }
+
 std::optional<sdbusplus::message::object_path>
     IsolatableHWs::getFRUInventoryPath(
         const std::pair<LocationCode, InstanceId>& fruDetails,
@@ -714,7 +742,7 @@ std::optional<sdbusplus::message::object_path>
             inventoryPathList->begin(), inventoryPathList->end(),
             [&fruInstId, &fruInvPathLookupFunc, this](const auto& path) {
             return fruInvPathLookupFunc(this->_bus, path, fruInstId);
-            });
+        });
 
         if (fruHwInvPath == inventoryPathList->end())
         {
@@ -1018,7 +1046,7 @@ std::optional<sdbusplus::message::object_path> IsolatableHWs::getInventoryPath(
                  this](const auto& path) {
                 return isolatedHwDetails->second._invPathFuncLookUp(
                     this->_bus, path, uniqIsolateHwKey);
-                });
+            });
 
             if (isolateHwPath == childsInventoryPath->end())
             {


### PR DESCRIPTION
There was a single dimm under ocmb earlier, now we have 2 dimms under
one ocmb.So, considering the last dimm as parent for ocmb in case of
multiple dimms as considering ocmb as parent is causing dimm numbering
issues on bonnell.

Test  Results:

Before:
Dimm numbers were same for both ocmbs.
```
root@p10bmc:/tmp# guard -l
ID         | ERROR      | Type     | Path
0x00000001 | 0x50004cce | fatal    | physical:sys-0/node-0/ocmb_chip-4
0x00000002 | 0x50004cce | fatal    | physical:sys-0/node-0/ocmb_chip-5
swetha@IBM-PF3XHYG0:~$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation
/Entries
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation
               /Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of System Hardware Isolation Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:29:47+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/2",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:30:13+00:00",
      "EntryType": "Event",
      "Id": "2",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    }
  ],
  "Members@odata.count": 2,
  "Name": "Hardware Isolation Entries"
}

```
After:
Dimm numbers are mapped correctly now.
```
root@p10bmc:/tmp/test# guard -l
ID         | ERROR      | Type      | Path
0x00000001 | 0x50004cce | fatal     | physical:sys-0/node-0/ocmb_chip-4
0x00000002 | 0x50004cce | fatal     | physical:sys-0/node-0/ocmb_chip-5
swetha@IBM-PF3XHYG0:~$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation
/Entries
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation
                /Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of System Hardware Isolation Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:29:47+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/2",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:30:13+00:00",
      "EntryType": "Event",
      "Id": "2",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm1"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    }
  ],
  "Members@odata.count": 2,
  "Name": "Hardware Isolation Entries"
}
```