### PR TITLE
common: Consider the last dimm as parent

### DIFF
--- a/src/common/isolatable_hardwares.cpp
+++ b/src/common/isolatable_hardwares.cpp
@@ -207,9 +207,10 @@ std::optional<
     IsolatableHWs::getIsotableHWDetails(
         const IsolatableHWs::HW_Details::HwId& id) const
 {
-    auto it = std::find_if(
-        _isolatableHWsList.begin(), _isolatableHWsList.end(),
-        [&id](const auto& isolatableHw) { return isolatableHw.first == id; });
+    auto it = std::find_if(_isolatableHWsList.begin(), _isolatableHWsList.end(),
+                           [&id](const auto& isolatableHw) {
+        return isolatableHw.first == id;
+    });
 
     if (it != _isolatableHWsList.end())
     {
@@ -735,7 +736,7 @@ std::optional<sdbusplus::message::object_path>
             inventoryPathList->begin(), inventoryPathList->end(),
             [&fruInstId, &fruInvPathLookupFunc, this](const auto& path) {
             return fruInvPathLookupFunc(this->_bus, path, fruInstId);
-        });
+            });
 
         if (fruHwInvPath == inventoryPathList->end())
         {
@@ -1039,7 +1040,7 @@ std::optional<sdbusplus::message::object_path> IsolatableHWs::getInventoryPath(
                  this](const auto& path) {
                 return isolatedHwDetails->second._invPathFuncLookUp(
                     this->_bus, path, uniqIsolateHwKey);
-            });
+                });
 
             if (isolateHwPath == childsInventoryPath->end())
             {

--- a/src/common/isolatable_hardwares.cpp
+++ b/src/common/isolatable_hardwares.cpp
@@ -646,7 +646,10 @@ std::optional<struct pdbg_target*>
              */
             devTreeTgt = pdbg_target_parent("ocmb", devTreeTgt);
         }
-
+        /**
+         * Though ocmb has Location Code available now we need to use dimm
+         * location code in case of bonnell.
+         */
         auto dimmCount = 0;
         struct pdbg_target* lastDimmTgt = nullptr;
         pdbg_for_each_target("dimm", devTreeTgt, lastDimmTgt)
@@ -662,16 +665,6 @@ std::optional<struct pdbg_target*>
                             "from phal cec device tree for the given phal cec "
                             "device tree target [{}]",
                             fruUnitDevTreePath)
-                    .c_str());
-            return std::nullopt;
-        }
-        else if (dimmCount > 1)
-        {
-            log<level::ERR>(
-                std::format("More [{}] dimm targets are present "
-                            "in phal cec device tree for the given phal cec "
-                            " device tree target [{}]",
-                            dimmCount, fruUnitDevTreePath)
                     .c_str());
             return std::nullopt;
         }


### PR DESCRIPTION
Previously, there was only one DIMM under OCMB. Now, we have two DIMMs
under one OCMB. Therefore, in the case of multiple DIMMs, we consider
the last DIMM as the parent for OCMB. This approach resolves DIMM
numbering issues on Bonnell, as considering OCMB as the parent was
causing discrepancies.

Test  Results:

Before:
Dimm numbers were same for both ocmbs.
```
root@p10bmc:/tmp# guard -l
ID         | ERROR      | Type     | Path
0x00000001 | 0x50004cce | fatal    | physical:sys-0/node-0/ocmb_chip-4
0x00000002 | 0x50004cce | fatal    | physical:sys-0/node-0/ocmb_chip-5
swetha@IBM-PF3XHYG0:~$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation
/Entries
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation
               /Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of System Hardware Isolation Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:29:47+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/2",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:30:13+00:00",
      "EntryType": "Event",
      "Id": "2",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    }
  ],
  "Members@odata.count": 2,
  "Name": "Hardware Isolation Entries"
}
```

After:
Dimm numbers are mapped correctly now.
```
root@p10bmc:/tmp/test# guard -l
ID         | ERROR      | Type      | Path
0x00000001 | 0x50004cce | fatal     | physical:sys-0/node-0/ocmb_chip-4
0x00000002 | 0x50004cce | fatal     | physical:sys-0/node-0/ocmb_chip-5
swetha@IBM-PF3XHYG0:~$ curl -k -H "X-Auth-Token: $bmc_token" -X GET
https://${bmc}/redfish/v1/Systems/system/LogServices/HardwareIsolation
/Entries
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation
                /Entries",
  "@odata.type": "#LogEntryCollection.LogEntryCollection",
  "Description": "Collection of System Hardware Isolation Entries",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:29:47+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm0"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices
                    /HardwareIsolation/Entries/2",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "AdditionalDataURI": "/redfish/v1/Systems/system/LogServices
                            /EventLog/Entries/2956/attachment",
      "Created": "2024-03-25T14:30:13+00:00",
      "EntryType": "Event",
      "Id": "2",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Memory/dimm1"
        }
      },
      "Message": "OpenCAPI Memory Buffer",
      "Name": "Hardware Isolation Entry",
      "Severity": "Critical"
    }
  ],
  "Members@odata.count": 2,
  "Name": "Hardware Isolation Entries"
}

```
Change-Id: I7c64d64d56bbfb9ff7094a751aee2e4ab417b4bf