### PR TITLE
nag: Ignore PELs with hidden property set to true

### DIFF
--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -257,6 +257,7 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
             uint32_t plid = 0;
             bool deconfigured = false;
             bool guarded = false;
+            bool hidden = false;
             uint64_t timestamp = 0;
             std::string callouts;
             std::string refCode;
@@ -343,7 +344,15 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
                                 timestamp = *timestampPtr;
                             }
                         }
-                    }
+                        else if (prop == "Hidden")
+                        {
+                            auto hiddenPtr = std::get_if<bool>(&propValue);
+                            if (hiddenPtr != nullptr)
+                            {
+                                hidden = *hiddenPtr;
+                            }
+                        }
+		    }
                 }
             }
 
@@ -369,6 +378,11 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
             if (guarded == true)
             {
                 continue; // will be captured as part of guard records
+            }
+
+            if (hidden == true)
+            {
+                continue;
             }
 
             // power and thermal err src starts with 1100


### PR DESCRIPTION
Faultlog application checks if deconfigured property is set to true in a PEL.

But there can be PELs which have the deconfigured
property set, but with hidden property also set,
in which case such PELs should not be considered for nag dump.

Whenever Hidden property is set in a PEL, faultlog is expected to ignore such a PEL.

Tested:
Recreated the error scenario with corrupted image side switch with PEL generated having deconfigured and hidden bits set to true.Verified that faultlog is no longer picking up the above PEL for a callout.

Before:
[
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22A"
    }
  },
  {
    "SERVICEABLE_EVENT": [
      {
        "CEC_ERROR_LOG": [
          {
            "Callout Section": {
              "Callout Count": 2,
              "Callouts": [
                {
                  "1. Priority": "High",
                  "Procedure": "HB00055"
                },
                {
                  "CCIN": "32A1",
                  "Location Code": "U78DA.ND0.WZS003T-P0-C27",
                  "Part Number": "03HD700",
                  "Priority": "High",
                  "Serial Number": "YH331T38403F"
                }
              ]
            },
            "DATE_TIME": "04/25/2024 08:01:04",
            "PLID": "0x900002ca",
            "SRC": "BC8A090F"
          },

After:
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-22A"
    }
  },
  {
    "POLICY": {
      "FCO_VALUE": 10,
      "MASTER": true,
      "PREDICTIVE": true
    }
  },
  {
    "DECONFIGURED": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C15",
      "PHYS_PATH": "physical:sys-0/node-0/proc-0/eq-1/fc-0",
      "PLID": 0,
      "REASON_DESCRIPTION": "FIELD CORE OVERRIDE",
      "TYPE": "POWER10 Fused Core"
    }
  },

Change-Id: I3d1b5248817a7d033737b47b16faa804d0301d6f