### PR TITLE
nag: Ignore PELs if hidden property is set.

### DIFF
--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -89,6 +89,7 @@ int UnresolvedPELs::getCount(sdbusplus::bus::bus& bus, bool ignorePwrFanPel)
                 "xyz.openbmc_project.Logging.Entry.Level.Informational";
             bool deconfigured = false;
             bool guarded = false;
+            bool hidden = false;
             std::string refCode;
             uint64_t timestamp = 0;
             for (const auto& [intf, properties] : interfaces)
@@ -140,6 +141,14 @@ int UnresolvedPELs::getCount(sdbusplus::bus::bus& bus, bool ignorePwrFanPel)
                                 deconfigured = *deconfigPtr;
                             }
                         }
+                        else if (prop == "Hidden")
+                        {
+                            auto hiddenPtr = std::get_if<bool>(&propValue);
+                            if (hiddenPtr != nullptr)
+                            {
+                                hidden = *hiddenPtr;
+                            }
+                        }
                         else if (prop == "Guard")
                         {
                             auto guardPtr = std::get_if<bool>(&propValue);
@@ -176,6 +185,11 @@ int UnresolvedPELs::getCount(sdbusplus::bus::bus& bus, bool ignorePwrFanPel)
             }
 
             if (deconfigured == false)
+            {
+                continue;
+            }
+
+            if (hidden == true)
             {
                 continue;
             }
@@ -352,7 +366,7 @@ void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
                                 hidden = *hiddenPtr;
                             }
                         }
-		    }
+                    }
                 }
             }
 


### PR DESCRIPTION
Faultlog application checks if deconfigured property is set to true in a PEL.

But there can be PELs which have the deconfigured
property set, but with hidden property also set,
in which case such PELs should not be considered for nag dump.

Whenever Hidden property is set in a PEL, faultlog is expected to ignore such a PEL.

Tested:
With PELs having deconfigured and hidden parameters set in a system, attempted to create fault log PEL and validated that the faultlog PEL is not getting created as PEL count is zero as the faultlog app is ignoring the PELs with hidden bit set.

Before:
bmc:~# faultlog -c
faultlog app to collect deconfig/guard records details Latest chassis poweron time read is :05/22/2024 09:34:39 faultlog GUARD_COUNT: 0, MAN_GUARD_COUNT: 37,
DECONFIG_REC_COUNT: 77 , PEL_COUNT: 2

After:
root@rain56bmc:~# faultlog -c
faultlog app to collect deconfig/guard records details Latest chassis poweron time read is :05/22/2024 09:34:39 faultlog GUARD_COUNT: 0, MAN_GUARD_COUNT: 37,
DECONFIG_REC_COUNT: 77 , PEL_COUNT: 0
There are no pending service actions ignoring creating fautlog pel

Change-Id: I5fd32b4c84d069bfccf4a20d4b6c28721f1b3739