### PR TITLE
record: Spare core support

### DIFF
--- a/include/hw_isolation_record/manager.hpp
+++ b/include/hw_isolation_record/manager.hpp
@@ -109,7 +109,7 @@ class Manager :
     void eraseEntry(const entry::EntryRecordId entryRecordId);
 
     /**
-     * @brief Delete all isolated hardware entires
+     * @brief Delete all isolated hardware entires except cores
      *
      * @return NULL
      */
@@ -363,17 +363,14 @@ class Manager :
     void handleHostIsolatedHardwares();
 
     /**
-     * @brief Resolve all entries.
+     * @brief clear all dbus entries.
      *
-     * @param[in] clearRecord - use to decide whether want to clear
-     *                          record from their preserved file.
-     *                          By default, it will clear record.
      * @return NULL
      *
-     * @note This function just resolve the entries, won't check
-     *       whether resolve operation is allowed or not like "deleteAll()".
+     * @note This function just removes the dbus entries, Use deleteAll() to
+     * resolve guard records.
      */
-    void resolveAllEntries(bool clearRecord = true);
+    void clearDbusEntries();
 
     /**
      * @brief Helper API to check whether hardware isolation record

--- a/include/hw_isolation_record/openpower_guard_interface.hpp
+++ b/include/hw_isolation_record/openpower_guard_interface.hpp
@@ -46,6 +46,15 @@ std::optional<GuardRecord> create(const EntityPath& entityPath,
 void clear(const uint32_t recordId);
 
 /**
+ * @brief Wrapper function for libguard::invalidateAll to delete all guard
+ * records
+ *
+ * @return NULL on success
+ *         Throw exception on failure
+ */
+void clearAll();
+
+/**
  * @brief Wrapper function for libguard::getAll to get all guard records
  *
  * @param[in] persistentTypeOnly - Used to decide whether wants to get all

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -425,7 +425,7 @@ void Manager::eraseEntry(const entry::EntryRecordId entryRecordId)
     _isolatedHardwares.erase(entryRecordId);
 }
 
-void Manager::resolveAllEntries(bool clearRecord)
+void Manager::clearDbusEntries()
 {
     auto entryIt = _isolatedHardwares.begin();
     while (entryIt != _isolatedHardwares.end())
@@ -437,7 +437,7 @@ void Manager::resolveAllEntries(bool clearRecord)
         // Continue other entries to delete if failed to delete one entry
         try
         {
-            entry->resolveEntry(clearRecord);
+            entry->resolveEntry(false);
         }
         catch (std::exception& e)
         {
@@ -798,7 +798,7 @@ void Manager::handleHostIsolatedHardwares()
     if ((records.size() == 0) && _isolatedHardwares.size() > 0)
     {
         // Clean up all entries association before delete.
-        resolveAllEntries(false);
+        clearDbusEntries();
         _isolatedHardwares.clear();
         return;
     }

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -213,7 +213,7 @@ std::pair<bool, sdbusplus::message::object_path> Manager::updateEntry(
                      [recordId, entityPath](const auto& isolatedHw) {
         return ((isolatedHw.second->getEntityPath() == entityPath) &&
                 (isolatedHw.second->getEntryRecId() == recordId));
-        });
+    });
 
     if (isolatedHwIt == _isolatedHardwares.end())
     {
@@ -679,10 +679,10 @@ void Manager::cleanupPersistedEcoCores()
 
             auto isNotIsolated = std::ranges::none_of(
                 _isolatedHardwares, [ecoCore](const auto& entry) {
-                    return (entry.second->getEntityPath() ==
-                            openpower_guard::EntityPath(ecoCore->data(),
-                                                        ecoCore->size()));
-                });
+                return (entry.second->getEntityPath() ==
+                        openpower_guard::EntityPath(ecoCore->data(),
+                                                    ecoCore->size()));
+            });
 
             if (isNotIsolated)
             {
@@ -844,9 +844,9 @@ void Manager::handleHostIsolatedHardwares()
                 std::stringstream ss;
                 std::for_each(entityPathRawData.begin(),
                               entityPathRawData.end(), [&ss](const auto& ele) {
-                                  ss << std::setw(2) << std::setfill('0')
-                                     << std::hex << (int)ele << " ";
-                              });
+                    ss << std::setw(2) << std::setfill('0') << std::hex
+                       << (int)ele << " ";
+                });
                 log<level::ERR>(std::format("More than one valid records exist "
                                             "for the same hardware [{}]",
                                             ss.str())

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -453,7 +453,7 @@ void Manager::deleteAll()
     // throws exception if not allowed
     hw_isolation::utils::isHwDeisolationAllowed(_bus);
 
-    resolveAllEntries();
+    openpower_guard::clearAll();
 }
 
 bool Manager::isValidRecord(const entry::EntryRecordId recordId)

--- a/src/hw_isolation_record/openpower_guard_interface.cpp
+++ b/src/hw_isolation_record/openpower_guard_interface.cpp
@@ -76,6 +76,11 @@ void clear(const uint32_t recordId)
     CALL_LIBGUARD_INTERFACE(libguard::clear(recordId);)
 }
 
+void clearAll()
+{
+    CALL_LIBGUARD_INTERFACE(libguard::invalidateAll();)
+}
+
 GuardRecords getAll(bool persistentTypeOnly)
 {
     GuardRecords records;


### PR DESCRIPTION
Calling invalidateAll method of libguard instead of invalidating one by
 one to support retention of core guard records and clear all other
records. This also supports clearing a single guard record (including core).

This change will cause the object paths to be deleted after deletion of all the guard records. So there might be a delay of 5-10 sec in clearing the object paths.

Change-Id: Ie0ff94ede36f39a98417be4f8b293d90495efd41
Signed-off-by: SwethaParasa <parasa.swetha1@ibm.com>