### PR TITLE
Ignore gard or deconfig records if the error type is spare

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,10 +4,10 @@ project('hardware_isolation', 'cpp', 'c',
     default_options: [
       'buildtype=debugoptimized',
       'warning_level=3',
-      'cpp_std=c++20',
+      'cpp_std=c++23',
       'werror=true',
     ],
-    meson_version: '>=0.58.0',
+    meson_version: '>=1.1.1',
     version: '1.0.0',
 )
 

--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -66,6 +66,12 @@ DeconfigDataList
     std::vector<std::string> pathList;
     for (const auto& elem : guardRecords)
     {
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            // if guarded due to spare ignore it
+            continue;
+        }
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -77,6 +77,12 @@ int GuardWithEidRecords::getCount(sdbusplus::bus::bus& bus,
         {
             continue;
         }
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            // if guarded due to spare ignore it
+            continue;
+        }
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {
@@ -189,6 +195,12 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             // ignore manual guard records
             if (elem.elogId == 0)
             {
+                continue;
+            }
+            if (elem.errType ==
+                static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+            {
+                // if guarded due to spare ignore it
                 continue;
             }
             auto physicalPath =

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -83,6 +83,12 @@ int GuardWithoutEidRecords::getCount(const GuardRecords& guardRecords)
             // only cater guards without a PEL
             continue;
         }
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            // if guarded due to spare ignore it
+            continue;
+        }
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {
@@ -109,6 +115,12 @@ void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
             if (elem.elogId != 0)
             {
                 // only cater guards without a PEL
+                continue;
+            }
+            if (elem.errType ==
+                static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+            {
+                // if guarded due to spare ignore it
                 continue;
             }
             auto physicalPath =


### PR DESCRIPTION
Do not capture gard and deconfig records with error type as spare in the faultlog json file.

faulty cores are replaced by spare cores so do not consider faulty cores replaced by spare cores as error.


Change-Id: Ie2df8d59b55657585c286e584a59dacb141ef7f4