### PR TITLE
ignore gard and deconfig records created with error type spare

### DIFF
--- a/src/faultlog/deconfig_records.cpp
+++ b/src/faultlog/deconfig_records.cpp
@@ -66,6 +66,12 @@ DeconfigDataList
     std::vector<std::string> pathList;
     for (const auto& elem : guardRecords)
     {
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            // if guarded due to spare ignore it
+            continue;
+        }
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {

--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -242,10 +242,27 @@ int main(int argc, char** argv)
         }
         catch (const std::exception& ex)
         {
-            std::cout << "failed to get system type " << std::endl;
+            lg2::info("failed to get system type ");
         }
         nlohmann::json system;
         system["SYSTEM_TYPE"] = propVal;
+
+        std::string systemSN{};
+        try
+        {
+            auto pVal = readProperty<Binary>(
+                bus, "xyz.openbmc_project.Inventory.Manager",
+                "/xyz/openbmc_project/inventory/system/chassis/"
+                "motherboard",
+                "com.ibm.ipzvpd.VSYS", "SE");
+            systemSN.assign(reinterpret_cast<const char*>(pVal.data()),
+                            pVal.size());
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::info("failed to get system s/n ");
+        }
+        system["SYSTEM_SN"] = systemSN;
 
         nlohmann::json systemHdr;
         systemHdr["SYSTEM"] = std::move(system);

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -77,6 +77,12 @@ int GuardWithEidRecords::getCount(sdbusplus::bus::bus& bus,
         {
             continue;
         }
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            // if guarded due to spare ignore it
+            continue;
+        }
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {
@@ -189,6 +195,12 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             // ignore manual guard records
             if (elem.elogId == 0)
             {
+                continue;
+            }
+            if (elem.errType ==
+                static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+            {
+                // if guarded due to spare ignore it
                 continue;
             }
             auto physicalPath =

--- a/src/faultlog/guard_without_eid_records.cpp
+++ b/src/faultlog/guard_without_eid_records.cpp
@@ -83,6 +83,12 @@ int GuardWithoutEidRecords::getCount(const GuardRecords& guardRecords)
             // only cater guards without a PEL
             continue;
         }
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            // if guarded due to spare ignore it
+            continue;
+        }
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {
@@ -109,6 +115,12 @@ void GuardWithoutEidRecords::populate(const GuardRecords& guardRecords,
             if (elem.elogId != 0)
             {
                 // only cater guards without a PEL
+                continue;
+            }
+            if (elem.errType ==
+                static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+            {
+                // if guarded due to spare ignore it
                 continue;
             }
             auto physicalPath =


### PR DESCRIPTION
spare cores replaces faulty cores and faulty cores are guarded or deconfigured with error type spare.

As spare cores are replacing faulty cores do not capture them in faultlog

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I4f09520522cdc241cc2736e859a1a08af577e91b