### PR TITLE
faultlog - add system serial number to the faultlog JSON file

### DIFF
--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -242,10 +242,27 @@ int main(int argc, char** argv)
         }
         catch (const std::exception& ex)
         {
-            std::cout << "failed to get system type " << std::endl;
+            lg2::info("failed to get system type ");
         }
         nlohmann::json system;
         system["SYSTEM_TYPE"] = propVal;
+
+        std::string systemSN{};
+        try
+        {
+            auto pVal = readProperty<Binary>(
+                bus, "xyz.openbmc_project.Inventory.Manager",
+                "/xyz/openbmc_project/inventory/system/chassis/"
+                "motherboard",
+                "com.ibm.ipzvpd.VSYS", "SE");
+            systemSN.assign(reinterpret_cast<const char*>(pVal.data()),
+                            pVal.size());
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::info("failed to get system s/n ");
+        }
+        system["SYSTEM_SN"] = systemSN;
 
         nlohmann::json systemHdr;
         systemHdr["SYSTEM"] = std::move(system);


### PR DESCRIPTION
As system serial number is used to determine the faulty system by the product engineers adding System serial number for the faultlog json file

faultlog json file captures all the garded, deconfigured hardware elements in JSON file which are used by the PE.

Fixes: 647272