### PR TITLE
faultlog - add system serial number to the faultlog JSON file

### DIFF
--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -242,10 +242,27 @@ int main(int argc, char** argv)
         }
         catch (const std::exception& ex)
         {
-            std::cout << "failed to get system type " << std::endl;
+             lg2::info("failed to get system type ");
         }
         nlohmann::json system;
         system["SYSTEM_TYPE"] = propVal;
+
+        std::string systemSN{};
+        try
+        {
+            auto pVal = readProperty<Binary>(
+                bus, "xyz.openbmc_project.Inventory.Manager",
+                "/xyz/openbmc_project/inventory/system/chassis/"
+                "motherboard",
+                "com.ibm.ipzvpd.VSYS", "SE");
+            systemSN.assign(reinterpret_cast<const char*>(pVal.data()),
+                            pVal.size());
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::info("failed to get system s/n ");
+        }
+        system["SYSTEM_SN"] = systemSN;
 
         nlohmann::json systemHdr;
         systemHdr["SYSTEM"] = std::move(system);


### PR DESCRIPTION
The system serial number is used to determine the faulty system by the product engineers adding system serial number for the faultlog json file

faultlog json file captures all the garded, deconfigured hardware elements in JSON file which are used by the PE.

Tested:
iroot@xxxx:~# busctl introspect xyz.openbmc_project.Inventory.Manager
    /xyz/openbmc_project/inventory/system/chassis/motherboard  com.ibm.ipzvpd.VSYS
NAME TYPE      SIGNATURE RESULT/VALUE            FLAGS
.SE  property  ay        7 49 51 57 70 50 51 48  emits-change writable

root@xxx:/tmp# ./faultlog -f
[
  {
    "SYSTEM": {
      "SYSTEM_SN": "139F230",
      "SYSTEM_TYPE": "9105-22A"
    }
  },


Change-Id: I5ea07a23d1969edba72cc79b61162ca6cdb5be08