### PR TITLE
faultlog - cater for spare core gard records

### DIFF
--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -77,6 +77,15 @@ int GuardWithEidRecords::getCount(sdbusplus::bus::bus& bus,
         {
             continue;
         }
+
+        // Ignore notifying caller by not updating the count if gard record
+        // is of type spare. Do collect gard record details though in JSON file.
+        if (elem.errType ==
+            static_cast<uint8_t>(openpower::guard::GardType::GARD_Spare))
+        {
+            continue;
+        }
+
         auto physicalPath = openpower::guard::getPhysicalPath(elem.targetId);
         if (!physicalPath.has_value())
         {
@@ -312,7 +321,7 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
                 json sectionJson = json::object();
 
                 // getLocationCode checks if attr is present in target else
-                // gets it from partent target
+                // gets it from parent target
                 ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
                 openpower::phal::pdbg::getLocationCode(guardedTarget.target,
                                                        attrLocCode);


### PR DESCRIPTION
Do not notify the caller if there are only spare core guard records, but collect
spare core gard reocrd details if there are other gard records or unresolved PELS.

Do not create a DeconfiguredHw PEL if there are only spare core gard records.

DeconfiguredHW PEL is created if the gard record count or unresloved PEL's count
is greater than zero. So change is made to not to consider spare core gard record
as part of calculating the gard record count.

HMC monitors DeconfiguredHw and initiates NAGDUMP.

Change-Id: I94419ab8f7343daf182c6a141b46d60608d8807e