### PR TITLE
faultlog : fix parser for callout data read from PEL

### DIFF
--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -4,8 +4,8 @@
 #include <sdbusplus/exception.hpp>
 #include <util.hpp>
 
+#include <regex>
 #include <sstream>
-
 namespace openpower::faultlog
 {
 
@@ -100,60 +100,52 @@ json parseCallout(const std::string callout)
     {
         return json::object();
     }
+    std::istringstream stream(callout);
+    std::string line;
 
-    // lambda method to split the string based on delimiter
-    auto splitString = [](const std::string& str, char delimiter) {
-        std::vector<std::string> tokens;
-        std::stringstream ss(str);
-        std::string token;
+    // Regular expression to capture key-value pairs (ignores the starting
+    // number)
+    // Example 
+    // 1. LocationCode:xxxx, CCIN:XXX, SN:xxxx, PN:xxxx, Priority:xxx
+    // 2. PN:xxxx, Priority:xxx
+    std::regex pattern(
+        R"((Location Code|Priority|PN|SN|CCIN):\s*([A-Za-z0-9.-]+))");
 
-        while (std::getline(ss, token, delimiter))
-        {
-            tokens.push_back(token);
-        }
-
-        return tokens;
-    };
-
-    std::vector<std::string> lines = splitString(callout, '\n');
+    int lineCount = 0;
     json calloutsJson = json::array();
-
-    for (const auto& line : lines)
+    // Read each line and parse it directly into a JSON object
+    while (std::getline(stream, line))
     {
-        std::vector<std::string> tokens = splitString(line, ',');
-        json calloutJson = json::object();
+        if (!line.empty())
+        { // Ignore empty lines
+            lineCount += 1;
+            json jsonObject; // JSON object to hold key-value pairs
+            std::smatch matches;
+            std::string::const_iterator searchStart(line.cbegin());
 
-        for (const auto& token : tokens)
-        {
-            std::size_t colonPos = token.find(':');
-
-            if (colonPos != std::string::npos)
+            // Use regex to find all key-value pairs in the current line
+            while (
+                std::regex_search(searchStart, line.cend(), matches, pattern))
             {
-                std::string key = token.substr(0, colonPos);
-                key.erase(0, key.find_first_not_of(' '));
-                key.erase(key.find_last_not_of(' ') + 1);
-                std::string value = token.substr(colonPos + 1);
-                value.erase(0, value.find_first_not_of(' '));
-                value.erase(value.find_last_not_of(' ') + 1);
-                if (key.find("Location Code") != std::string::npos)
-                {
-                    key = "Location Code";
-                }
-                else if (key.find("SN") != std::string::npos)
+                std::string key = matches[1].str();
+                if (key == "SN")
                 {
                     key = "Serial Number";
                 }
-                else if (key.find("PN") != std::string::npos)
+                else if (key == "PN")
                 {
                     key = "Part Number";
                 }
-                calloutJson[key] = value;
+                jsonObject[key] =
+                    matches[2].str(); // Assign key-value pairs to JSON object
+                searchStart = matches.suffix().first; // Move to the next match
             }
+            calloutsJson.push_back(
+                jsonObject); // Add the JSON object to the array
         }
-        calloutsJson.push_back(calloutJson);
     }
     json sectionJson = json::object();
-    sectionJson["Callout Count"] = lines.size();
+    sectionJson["Callout Count"] = lineCount;
     sectionJson["Callouts"] = calloutsJson;
     return sectionJson;
 }
@@ -199,7 +191,6 @@ bool isECOcore(struct pdbg_target* target)
 
 std::string pdbgTargetName(struct pdbg_target* target)
 {
-
     if (isECOcore(target))
     {
         return "Cache-Only Core";


### PR DESCRIPTION
Due to some parsing error some stray characters are added to the callout section in the faultlog.json file

Now modified to use regular expression rather than "C" way of parsing.

Example: callout number 3. is added to the Priority key value Before:
              "Callouts": [
                {
                  "3. Priority": "Medium",
                  "Part Number": "PWRSPLY"
                }
After:
              "Callouts": [
                {
                  "Priority": "Medium"
                  "Part Number": "PWRSPLY",
                }


Change-Id: Iea8b62e018db4a6f0cae069976bedc88abe7e2c5