### PR TITLE
Develop a CLI Application for creating system guard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,3 +113,4 @@ configure_file(
     )
 
 subdir('src')
+subdir('tools')

--- a/tools/create_pel.cpp
+++ b/tools/create_pel.cpp
@@ -1,0 +1,128 @@
+#include "create_pel.hpp"
+
+#include <fcntl.h>
+#include <libekb.H>
+#include <phal_exception.H>
+#include <unistd.h>
+
+#include <phosphor-logging/elog.hpp>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <format>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+namespace openpower {
+using namespace phosphor::logging;
+
+namespace guard {
+namespace pel {
+
+constexpr auto loggingObjectPath = "/xyz/openbmc_project/logging";
+constexpr auto loggingInterface = "xyz.openbmc_project.Logging.Create";
+constexpr auto opLoggingInterface = "org.open_power.Logging.PEL";
+
+using Level = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+
+std::string getService(sdbusplus::bus::bus &bus, const std::string &intf,
+                       const std::string &path) {
+  constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
+  constexpr auto MAPPER_PATH = "/xyz/openbmc_project/object_mapper";
+  constexpr auto MAPPER_INTERFACE = "xyz.openbmc_project.ObjectMapper";
+  try {
+    auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_PATH,
+                                      MAPPER_INTERFACE, "GetObject");
+
+    mapper.append(path, std::vector<std::string>({intf}));
+
+    auto mapperResponseMsg = bus.call(mapper);
+    std::map<std::string, std::vector<std::string>> mapperResponse;
+    mapperResponseMsg.read(mapperResponse);
+
+    if (mapperResponse.empty()) {
+      throw std::runtime_error("Empty mapper response for GetObject");
+    }
+    return mapperResponse.begin()->first;
+  } catch (const sdbusplus::exception::exception &ex) {
+    throw;
+  }
+}
+
+uint32_t createPelWithFFDCfiles(const std::string &event,
+                                const FFDCData &ffdcData,
+                                const Severity &severity,
+                                const FFDCInfo &ffdcInfo) {
+  uint32_t plid = 0;
+  try {
+    auto bus = sdbusplus::bus::new_default();
+
+    std::unordered_map<std::string, std::string> additionalData;
+    for (auto &data : ffdcData) {
+      additionalData.emplace(data);
+    }
+
+    auto service = getService(bus, opLoggingInterface, loggingObjectPath);
+    auto method =
+        bus.new_method_call(service.c_str(), loggingObjectPath,
+                            opLoggingInterface, "CreatePELWithFFDCFiles");
+    auto level =
+        sdbusplus::xyz::openbmc_project::Logging::server::convertForMessage(
+            severity);
+    method.append(event, level, additionalData, ffdcInfo);
+    auto response = bus.call(method);
+
+    // reply will be tuple containing bmc log id, platform log id
+    std::tuple<uint32_t, uint32_t> reply = {0, 0};
+
+    // parse dbus response into reply
+    response.read(reply);
+    plid = std::get<1>(reply); // platform log id is tuple "second"
+  } catch (const sdbusplus::exception::exception &e) {
+    throw;
+  } catch (const std::exception &e) {
+    throw;
+  }
+  return plid;
+}
+
+FFDCFile::FFDCFile(const json &pHALCalloutData)
+    : calloutData(pHALCalloutData.dump()),
+      calloutFile("/tmp/phalPELCalloutsJson.XXXXXX"), fileFD(-1) {
+  // create callout file
+  fileFD = mkostemp(const_cast<char *>(calloutFile.c_str()), O_RDWR);
+
+  if (fileFD == -1) {
+    throw std::runtime_error("Failed to create phalPELCallouts file");
+  }
+
+  // write callout data
+  ssize_t rc = write(fileFD, calloutData.c_str(), calloutData.size());
+
+  if (rc == -1) {
+    throw std::runtime_error("Failed to write phalPELCallouts info");
+  }
+
+  // set callout file seek pos
+  int seekrc = lseek(fileFD, 0, SEEK_SET);
+
+  if (seekrc == -1) {
+    throw std::runtime_error("Failed to set SEEK_SET for phalPELCallouts file");
+  }
+}
+
+FFDCFile::~FFDCFile() {
+  close(fileFD);
+  std::remove(calloutFile.c_str());
+}
+
+int FFDCFile::getFileFD() const { return fileFD; }
+
+} // namespace pel
+} // namespace guard
+} // namespace openpower

--- a/tools/create_pel.hpp
+++ b/tools/create_pel.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <phal_exception.H>
+
+#include <nlohmann/json.hpp>
+#include <xyz/openbmc_project/Logging/Create/server.hpp>
+#include <xyz/openbmc_project/Logging/Entry/server.hpp>
+
+#include <string>
+#include <vector>
+namespace openpower {
+namespace guard {
+namespace pel {
+using FFDCData = std::vector<std::pair<std::string, std::string>>;
+
+using FFDCInfo = std::vector<std::tuple<
+    sdbusplus::xyz::openbmc_project::Logging::server::Create::FFDCFormat,
+    uint8_t, uint8_t, sdbusplus::message::unix_fd>>;
+
+using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+
+using json = nlohmann::json;
+
+using namespace openpower::phal;
+
+/**
+ * Create a PEL with FFDC file
+ *
+ * @brief This method creates a PEL based on the FFDC file provided.
+ *
+ * @param  event - the event type
+ * @param  ffdcData - vector of additional ffdc data
+ * @param  severity - the severity level
+ * @param  ffcdInfo - a vector of tuples containing ffdc file info
+ * @return Platform log id or 0 if error
+ */
+uint32_t createPelWithFFDCfiles(const std::string &event,
+                                const FFDCData &ffdcData,
+                                const Severity &severity,
+                                const FFDCInfo &ffdcInfo);
+
+/**
+ * @brief Get DBUS service for input interface via mapper call
+ *
+ * @param[in] bus -  DBUS Bus Object
+ * @param[in] intf - DBUS Interface
+ * @param[in] path - DBUS Object Path
+ *
+ * @return distinct dbus name for input interface/path
+ **/
+std::string getService(sdbusplus::bus::bus &bus, const std::string &intf,
+                       const std::string &path);
+
+/**
+ * @class FFDCFile
+ * @brief This class is used to create ffdc data file and to get fd
+ *
+ * Example FFDC file : phalPELCalloutsJson.nxUHIp
+ * [{"EntityPath":[35,1,0,2,0,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"GuardType":"GARD_Fatal","Guarded":true,"LocationCode":"Ufcs-P0-C12","Priority":"H","physical_path":"physical:sys-0/node-0/dimm-0","severity":"fatal"}]
+ */
+class FFDCFile {
+public:
+  FFDCFile() = delete;
+  FFDCFile(const FFDCFile &) = delete;
+  FFDCFile &operator=(const FFDCFile &) = delete;
+  FFDCFile(FFDCFile &&) = delete;
+  FFDCFile &operator=(FFDCFile &&) = delete;
+
+  /**
+   * Used to pass json object to create unique ffdc file by using
+   * passed json data.
+   */
+  explicit FFDCFile(const json &pHALCalloutData);
+
+  /**
+   * Used to remove created ffdc file.
+   */
+  ~FFDCFile();
+
+  /**
+   * Used to get created ffdc file file descriptor id.
+   *
+   * @return file descriptor id
+   */
+  int getFileFD() const;
+
+private:
+  /**
+   * Used to store callout ffdc data from passed json object.
+   */
+  std::string calloutData;
+
+  /**
+   * Used to store unique ffdc file name.
+   */
+  std::string calloutFile;
+
+  /**
+   * Used to store created ffdc file descriptor id.
+   */
+  int fileFD;
+
+}; // FFDCFile end
+
+} // namespace pel
+} // namespace guard
+} // namespace openpower

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,25 @@
+cxx = meson.get_compiler('cpp')
+
+sdbusplus = dependency(
+    'sdbusplus',
+    fallback: [
+        'sdbusplus',
+        'sdbusplus_dep'
+    ],  
+)
+
+libdtapi = dependency('libdt-api')
+libguard = cpp.find_library('libguard')
+libpdbg = meson.get_compiler('c').find_library('libpdbg')
+phosphor_logging = dependency(
+    'phosphor-logging',
+    fallback: ['phosphor-logging', 'phosphor_logging_dep'],
+    )
+
+executable(
+    'sysguard',
+    'create_pel.cpp',
+	'systemguard.cpp',
+    dependencies: [ sdbusplus, phosphor_logging, libdtapi, libguard, libpdbg],
+	install:true,
+)

--- a/tools/systemguard.cpp
+++ b/tools/systemguard.cpp
@@ -1,0 +1,226 @@
+#include "create_pel.hpp"
+#include "xyz/openbmc_project/Logging/Entry/server.hpp"
+
+#include <attributes_info.H>
+
+#include <CLI/CLI.hpp>
+#include <libguard/guard_interface.hpp>
+#include <nlohmann/json.hpp>
+#include <xyz/openbmc_project/Logging/Create/server.hpp>
+
+#include <iostream>
+extern "C" {
+#include "libpdbg.h"
+}
+namespace pel = openpower::guard::pel;
+std::map<std::string, std::string> guardMap = {
+    {"spare", "GARD_Spare"}, {"unrecoverable", "GARD_Unrecoverable"},
+    {"fatal", "GARD_Fatal"}, {"predictive", "GARD_Predictive"},
+    {"power", "GARD_Power"}, {"phyp", "GARD_PHYP"}};
+
+std::map<std::string, pel::Severity> sevMap = {
+    {"GARD_Spare", pel::Severity::Notice},
+    {"GARD_Unrecoverable", pel::Severity::Critical},
+    {"GARD_Fatal", pel::Severity::Critical},
+    {"GARD_Predictive", pel::Severity::Warning},
+    {"GARD_Power", pel::Severity::Warning},
+    {"GARD_PHYP", pel::Severity::Warning}};
+
+using FFDCFormat =
+    sdbusplus::xyz::openbmc_project::Logging::server::Create::FFDCFormat;
+/** Data structure to pass to pdbg_target_traverse callback method*/
+struct GuardedTarget {
+  pdbg_target *target = nullptr;
+  std::string phyDevPath;
+  GuardedTarget(const std::string &path) : phyDevPath(path) {}
+};
+
+void pdbgLogCallback(int, const char *fmt, va_list ap) {
+  va_list vap;
+  va_copy(vap, ap);
+  std::vector<char> logData(1 + std::vsnprintf(nullptr, 0, fmt, ap));
+  std::vsnprintf(logData.data(), logData.size(), fmt, vap);
+  va_end(vap);
+  std::string logstr(logData.begin(), logData.end());
+  std::cout << "PDBG:" << logstr << std::endl;
+}
+
+/**
+ * @brief Get PDBG target matching the guarded target physicalpath
+ *
+ * This callback function is called as part of the recursive method
+ * pdbg_target_traverse, recursion will exit when the method return 1
+ * else continues till the target is found
+ *
+ * @param[in] target - pdbg target to compare
+ * @param[inout] priv - data structure passed to the callback method
+ *
+ * @return 1 when target is found else 0
+ */
+int getGuardedTarget(struct pdbg_target *target, void *priv) {
+  GuardedTarget *guardTarget = reinterpret_cast<GuardedTarget *>(priv);
+  ATTR_PHYS_DEV_PATH_Type phyPath;
+  if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, phyPath)) {
+    if (strcmp(phyPath, guardTarget->phyDevPath.c_str()) == 0) {
+      guardTarget->target = target;
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ *
+ * @brief Get the location code of the target to be guarded
+ *
+ * @param[in] trgt - a pdbg target
+ *
+ * @return A string containing the FRU location code of the given chip. An empty
+ *         string indicates the target was null or the attribute does not exist
+ *         for this target.
+ */
+std::string getLocationCode(pdbg_target *trgt) {
+  if (nullptr == trgt) {
+    return std::string{};
+  }
+  ATTR_LOCATION_CODE_Type val;
+  if (DT_GET_PROP(ATTR_LOCATION_CODE, trgt, val)) {
+    // Get the immediate parent in the devtree path and try again.
+    return getLocationCode(pdbg_target_parent(nullptr, trgt));
+  }
+  return val;
+}
+
+/**
+ * @brief convert input physical path to device tree understandable format
+ *
+ * @param[in] input - physical path of target to be guarded
+ *
+ * @return Device tree understandable physical path
+ **/
+std::string getDevTreePhyPathFormat(std::string_view input) {
+  constexpr std::string_view prefix = "physical:";
+
+  // Convert input to lowercase using std::ranges::transform
+  std::string lowercase_input(input);
+  std::ranges::transform(lowercase_input, lowercase_input.begin(),
+                         [](unsigned char c) { return std::tolower(c); });
+
+  // Check if the input starts with "physical:"
+  std::string result;
+  if (!lowercase_input.starts_with(prefix)) {
+    result = std::string(prefix) + lowercase_input;
+  } else {
+    result = std::string(lowercase_input);
+  }
+
+  // Check if the result starts with "physical:/"
+  constexpr std::string_view unwanted_slash = "physical:/";
+  if (result.starts_with(unwanted_slash)) {
+    result.erase(prefix.size(), 1); // Remove the extra slash
+  }
+
+  return result;
+}
+
+/**
+ * @brief Create a PEL with system guard
+ *
+ * @param[in] guardedTarget - a structure containing the info of the target to
+ *be guarded
+ * @param[in] sev - severity of the guard
+ *
+ **/
+void createPELWithSystemGuard(struct GuardedTarget &guardedTarget,
+                              const std::string sev) {
+  nlohmann::json pelJson;
+  ATTR_PHYS_BIN_PATH_Type binPath;
+  auto event = "org.open_power.Logging.Error.TestError3";
+  pel::FFDCData additionalData;
+  pelJson["GuardType"] = guardMap[sev];
+  pel::Severity severity = sevMap[guardMap[sev]];
+  pelJson["physical_path"] = guardedTarget.phyDevPath;
+  pelJson["severity"] = sev;
+  pelJson["Guarded"] = true;
+  if (!DT_GET_PROP(ATTR_PHYS_BIN_PATH, guardedTarget.target, binPath)) {
+    pelJson["EntityPath"] = binPath;
+  }
+  pelJson["Priority"] = "H";
+  pelJson["LocationCode"] = getLocationCode(guardedTarget.target);
+  nlohmann::json pelJsonArr = nlohmann::json::array();
+  pelJsonArr.push_back(pelJson);
+  try {
+    pel::FFDCFile file(pelJsonArr);
+    int fd = file.getFileFD();
+    pel::FFDCInfo ffdcInfo{{FFDCFormat::JSON, static_cast<uint8_t>(0xCA),
+                            static_cast<uint8_t>(0x01), fd}};
+    pel::createPelWithFFDCfiles(event, additionalData, severity, ffdcInfo);
+  } catch (const std::exception &ex) {
+    std::cerr << "Failed to create guard" << std::endl;
+  }
+}
+
+int main(int argc, char **argv) {
+  try {
+    CLI::App app{"Tool to create system guards"};
+    std::string phyDevPath;
+    std::optional<std::string> sev;
+    app.set_help_flag("-h, --help", "CLI tool options");
+    app.add_option("-c, --create", phyDevPath,
+                   "Create Guard record, expects physical path as input");
+    app.add_option("-s, --severity", sev,
+                   "Specifies the severity level of the guard "
+                   "(<Predictive/Fatal/Unrecoverable>). Defaults to Predictive "
+                   "if no value is provided");
+    CLI11_PARSE(app, argc, argv);
+    openpower::guard::libguard_init();
+
+    if (phyDevPath.empty()) {
+      std::cerr << "Please enter a valid target physical path" << std::endl;
+      return -1;
+    }
+
+    if (sev) {
+      std::string severity = *sev;
+      std::ranges::transform(severity, severity.begin(),
+                             [](unsigned char c) { return std::tolower(c); });
+      *sev = severity;
+      if (severity != "predictive" && severity != "fatal") {
+        std::cerr << "Please enter a valid severity" << std::endl;
+      }
+    } else {
+      *sev = "predictive";
+    }
+    std::cerr << "Creating System guard of type " << *sev
+              << " on the target with physical path " << phyDevPath
+              << std::endl;
+    constexpr auto devtree =
+        "/var/lib/phosphor-software-manager/pnor/rw/DEVTREE";
+
+    // PDBG_DTB environment variable set to CEC device tree path
+    if (setenv("PDBG_DTB", devtree, 1)) {
+      std::cerr << "Failed to set PDBG_DTB: " << strerror(errno) << std::endl;
+      return -1;
+    }
+
+    // initialize the targeting system
+    if (!pdbg_targets_init(NULL)) {
+      std::cerr << "pdbg_targets_init failed" << std::endl;
+      return -1;
+    }
+
+    // set log level and callback function
+    pdbg_set_loglevel(PDBG_DEBUG);
+    pdbg_set_logfunc(pdbgLogCallback);
+    GuardedTarget guardedTarget(getDevTreePhyPathFormat(phyDevPath));
+    auto ret = pdbg_target_traverse(nullptr, getGuardedTarget, &guardedTarget);
+    if (ret == 0) {
+      std::cerr << "Please enter a valid physical path" << std::endl;
+      return -1;
+    }
+    createPELWithSystemGuard(guardedTarget, *sev);
+  } catch (const std::exception &ex) {
+    std::cerr << "Exception: " << ex.what() << std::endl;
+  }
+  return 0;
+}


### PR DESCRIPTION
Test Results:

```
root@p10bmc:/tmp/test# sysguard -c  physical:sys-0/node-0/dimm-0 -s
                       critical
Creating System guard of type critical on the target with physical path physical:sys-0/node-0/dimm-0
root@p10bmc:/tmp/test# guard -l
ID         | ERROR      | Type           | Path
0x00000001 | 0x5000000d | fatal          | physical:sys-0/node-0/dimm-0

Nov 21 11:19:12 p10bmc phosphor-log-manager[398]: GUARD: (23 01 00 02 00 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ) Nov 21 11:19:12 p10bmc phosphor-log-manager[398]: Created PEL 0x5000000d (BMC ID 14) with SRC BD8D2006

root@p10bmc:/tmp/test# sysguard -c  physical:sys-0/node-0/dimm-2 Creating System guard of type warning on the target with physical path physical:sys-0/node-0/dimm-2
root@p10bmc:/tmp/test# guard -l
ID         | ERROR      | Type           | Path
0x00000001 | 0x5000000d | fatal          | physical:sys-0/node-0/dimm-0
0x00000002 | 0x5000000e | predictive     | physical:sys-0/node-0/dimm-1
0x00000003 | 0x5000000f | predictive     | physical:sys-0/node-0/dimm-2

Nov 21 11:20:12 p10bmc phosphor-log-manager[398]: GUARD: (23 01 00 02 00 03 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ) Nov 21 11:20:12 p10bmc phosphor-log-manager[398]: Created PEL 0x5000000f (BMC ID 15) with SRC BD8D2006

root@p10bmc:/tmp/test# peltool -i 0x5000000f
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Created at":               "11/21/2024 11:20:12",
    "Committed at":             "11/21/2024 11:20:12",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000000F",
    "Entry Id":                 "0x5000000F",
    "BMC Event Log Id":         "15"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "BMC Firmware",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc error logging",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "True",
    "Error Details": {
        "Message":              "This is a test predictive error"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD8D2006",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "01000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Normal Hardware FRU",
            "Priority":         "Mandatory, replace all with this type
                                 as a unit",
            "Location Code":    "U78DA.ND0.1234567-P0-C13",
            "Part Number":      "03HD708",
            "CCIN":             "32A2",
            "Serial Number":    "YH301T12ABCD"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-22A",
    "Reporting Serial Number":  "SIMP10R",
    "FW Released Ver":          "NL1110_018",
    "FW SubSys Version":        "fw1110.00-3.35",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD8D2006_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-22A",
    "Serial Number":            "SIMP10R"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "0.10 0.07 0.09",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 1h 8m 2s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "DIMMs Additional Info": [
        {
            "DRAM Manufacturer ID": [
                "0x80",
                "0xad"
            ],
            "Location Code": "U78DA.ND0.1234567-P0-C13"
        }
    ],
    "FW Version ID": "fw1110.00-3.35-1110.2447.20241118a (NL1110_018)",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Data": [
        {
            "EntityPath": [
                35,
                1,
                0,
                2,
                0,
                3,
                2,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0,
                0
            ],
            "GuardType": "GARD_Predictive",
            "Guarded": true,
            "LocationCode": "Ufcs-P0-C13",
            "Priority": "H",
            "physical_path": "physical:sys-0/node-0/dimm-2",
            "severity": "warning"
        }
    ]
}
}
```

Change-Id: I580d672dd00e46de1e3eed2a99bfc1749b7c2238