### PR TITLE
Remove errorlog association on PEL deletion

### DIFF
--- a/include/common/utils.hpp
+++ b/include/common/utils.hpp
@@ -183,12 +183,15 @@ void setEnabledProperty(sdbusplus::bus::bus& bus,
  *
  * @param[in] bus - Bus to attach to.
  * @param[in] eid - The EID (aka PEL ID) to get BMC log object path
+ * @param[in] createPELWithError - A flag to indicate if an error needs to be
+ * created if the errorlog object path is not found
  *
  * @return The BMC log object path
  *         Empty optional on failure
  */
 std::optional<sdbusplus::message::object_path>
-    getBMCLogPath(sdbusplus::bus::bus& bus, const uint32_t eid);
+    getBMCLogPath(sdbusplus::bus::bus& bus, const uint32_t eid,
+                  bool createPELWithError = false);
 
 /**
  * @brief Helper function to get the instance id from the given

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -2,6 +2,8 @@
 
 #include "common/utils.hpp"
 
+#include "common/error_log.hpp"
+
 #include "common/phal_devtree_utils.hpp"
 
 #include <xyz/openbmc_project/State/Chassis/server.hpp>
@@ -248,7 +250,8 @@ void setEnabledProperty(sdbusplus::bus::bus& bus,
 }
 
 std::optional<sdbusplus::message::object_path>
-    getBMCLogPath(sdbusplus::bus::bus& bus, const uint32_t eid)
+    getBMCLogPath(sdbusplus::bus::bus& bus, const uint32_t eid,
+                  bool createPELWithError)
 {
     // If EID is "0" means, no bmc error log.
     if (eid == 0)
@@ -279,10 +282,18 @@ std::optional<sdbusplus::message::object_path>
     {
         log<level::ERR>(
             fmt::format("Exception [{}] when trying to get BMC log path "
-                        "for the given EID (aka PEL ID) [{}]",
+                        "for the given EID (aka PEL ID) [{}], removing the PEL association",
                         e.what(), eid)
                 .c_str());
-        return std::nullopt;
+        if (createPELWithError)
+        {
+            error_log::createErrorLog(error_log::HwIsolationGenericErrMsg,
+                                      error_log::Level::Informational,
+                                      error_log::CollectTraces);
+        }
+        // Return the default path,  the record shall be displayed without the
+        // errorlog association
+        return sdbusplus::message::object_path();
     }
 }
 

--- a/src/hw_isolation_event/hw_status_manager.cpp
+++ b/src/hw_isolation_event/hw_status_manager.cpp
@@ -377,26 +377,7 @@ void Manager::restoreHardwaresStatusEvent(bool osRunning)
                                 eventMsg = "Error";
                                 eventSeverity = event::EventSeverity::Critical;
 
-                                auto logObjPath =
-                                    utils::getBMCLogPath(_bus, eId);
-                                if (!logObjPath.has_value())
-                                {
-                                    log<level::ERR>(
-                                        fmt::format(
-                                            "Skipping to create the hardware "
-                                            "status event because unable to "
-                                            "find the bmc error log object "
-                                            "path for the given "
-                                            "deconfiguration EID [{}] which "
-                                            "isolated the hardware [{}]",
-                                            eId, hwInventoryPath->str)
-                                            .c_str());
-                                    error_log::createErrorLog(
-                                        error_log::HwIsolationGenericErrMsg,
-                                        error_log::Level::Informational,
-                                        error_log::CollectTraces);
-                                    continue;
-                                }
+                                auto logObjPath = utils::getBMCLogPath(_bus, eId, true);
                                 eventErrLogPath = logObjPath->str;
                             }
                             else

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -507,24 +507,7 @@ void Manager::createEntryForRecord(const openpower_guard::GuardRecord& record,
 
         auto bmcErrorLogPath = utils::getBMCLogPath(_bus, record.elogId);
         std::string strBmcErrorLogPath{};
-        if (!bmcErrorLogPath.has_value())
-        {
-            if (!isRestorePath)
-            {
-                log<level::ERR>(
-                    fmt::format("Skipping to restore a given isolated "
-                                "hardware [{}] : Due to failure to get BMC "
-                                "error log path "
-                                "by isolated hardware EID (aka PEL ID) [{:#X}]",
-                                ss.str(), record.elogId)
-                        .c_str());
-                return;
-            }
-        }
-        else
-        {
-            strBmcErrorLogPath = bmcErrorLogPath->str;
-        }
+        strBmcErrorLogPath = bmcErrorLogPath->str;
 
         auto entrySeverity = entry::utils::getEntrySeverityType(
             static_cast<openpower_guard::GardType>(record.errType));
@@ -594,18 +577,6 @@ void Manager::updateEntryForRecord(const openpower_guard::GuardRecord& record,
     updateEcoCoresList(ecoCore, entityPathRawData);
 
     auto bmcErrorLogPath = utils::getBMCLogPath(_bus, record.elogId);
-
-    if (!bmcErrorLogPath.has_value())
-    {
-        log<level::ERR>(
-            fmt::format(
-                "Skipping to restore a given isolated "
-                "hardware [{}] : Due to failure to get BMC error log path "
-                "by isolated hardware EID (aka PEL ID) [{}]",
-                ss.str(), record.elogId)
-                .c_str());
-        return;
-    }
 
     auto entrySeverity = entry::utils::getEntrySeverityType(
         static_cast<openpower_guard::GardType>(record.errType));


### PR DESCRIPTION
If a system guard's associated PEL is removed, the update to the guard record is skipped in the restore path.

As the guard still exists, it is better to update the guard without the errorlog association. The gui could show a system guard (predictive/ fatal) without the errorlog.