### PR TITLE
Remove errorlog association on PEL deletion

### DIFF
--- a/include/common/utils.hpp
+++ b/include/common/utils.hpp
@@ -181,12 +181,15 @@ void setEnabledProperty(sdbusplus::bus::bus& bus,
  *
  * @param[in] bus - Bus to attach to.
  * @param[in] eid - The EID (aka PEL ID) to get BMC log object path
+ * @param[in] createPELWithError - A flag to indicate if an error needs to be
+ * created if the errorlog object path is not found
  *
  * @return The BMC log object path
  *         Empty optional on failure
  */
 std::optional<sdbusplus::message::object_path>
-    getBMCLogPath(sdbusplus::bus::bus& bus, const uint32_t eid);
+    getBMCLogPath(sdbusplus::bus::bus& bus, const uint32_t eid,
+                  bool createPELWithError = false);
 
 /**
  * @brief Helper function to get the instance id from the given

--- a/src/hw_isolation_event/hw_status_manager.cpp
+++ b/src/hw_isolation_event/hw_status_manager.cpp
@@ -346,24 +346,7 @@ bool Manager::populateDetailsToCreateEvent(
                     eventMsg = "Error";
                     eventSeverity = event::EventSeverity::Critical;
 
-                    auto logObjPath = utils::getBMCLogPath(_bus, eId);
-                    if (!logObjPath.has_value())
-                    {
-                        log<level::ERR>(
-                            std::format("Skipping to create the hardware "
-                                        "status event because unable to "
-                                        "find the bmc error log object "
-                                        "path for the given "
-                                        "deconfiguration EID [{}] which "
-                                        "isolated the hardware [{}]",
-                                        eId, hwInventoryPath->str)
-                                .c_str());
-                        error_log::createErrorLog(
-                            error_log::HwIsolationGenericErrMsg,
-                            error_log::Level::Informational,
-                            error_log::CollectTraces);
-                        return false;
-                    }
+                    auto logObjPath = utils::getBMCLogPath(_bus, eId, true);
                     eventErrLogPath = logObjPath->str;
                 }
                 else

--- a/src/hw_isolation_record/manager.cpp
+++ b/src/hw_isolation_record/manager.cpp
@@ -505,24 +505,7 @@ void Manager::createEntryForRecord(const openpower_guard::GuardRecord& record,
 
         auto bmcErrorLogPath = utils::getBMCLogPath(_bus, record.elogId);
         std::string strBmcErrorLogPath{};
-        if (!bmcErrorLogPath.has_value())
-        {
-            if (!isRestorePath)
-            {
-                log<level::ERR>(
-                    std::format("Skipping to restore a given isolated "
-                                "hardware [{}] : Due to failure to get BMC "
-                                "error log path "
-                                "by isolated hardware EID (aka PEL ID) [{:#X}]",
-                                ss.str(), record.elogId)
-                        .c_str());
-                return;
-            }
-        }
-        else
-        {
-            strBmcErrorLogPath = bmcErrorLogPath->str;
-        }
+        strBmcErrorLogPath = bmcErrorLogPath->str;
 
         auto entrySeverity = entry::utils::getEntrySeverityType(
             static_cast<openpower_guard::GardType>(record.errType));
@@ -591,18 +574,6 @@ void Manager::updateEntryForRecord(const openpower_guard::GuardRecord& record,
     updateEcoCoresList(ecoCore, entityPathRawData);
 
     auto bmcErrorLogPath = utils::getBMCLogPath(_bus, record.elogId);
-
-    if (!bmcErrorLogPath.has_value())
-    {
-        log<level::ERR>(
-            std::format(
-                "Skipping to restore a given isolated "
-                "hardware [{}] : Due to failure to get BMC error log path "
-                "by isolated hardware EID (aka PEL ID) [{}]",
-                ss.str(), record.elogId)
-                .c_str());
-        return;
-    }
 
     auto entrySeverity = entry::utils::getEntrySeverityType(
         static_cast<openpower_guard::GardType>(record.errType));


### PR DESCRIPTION
If a system guard's associated PEL is removed, the guard was skipped to be updated in the GUI as the association is lost. The following error was displayed.

```Skipping to restore a given isolated hardware [23 01 00 02 00 03 00 ] :
Due to failure to get BMC error log path by isolated hardware EID (aka
PEL ID) [1342178283]```

As the guard still exists, it is better to update the guard without the
errorlog association. The gui could show a system guard (predictive/
fatal) without the errorlog.

Cherry picked the change from 1110.

Tested and found it working as expected