### PR TITLE
faultlog: Add location code to ResourceActions

### DIFF
--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -32,7 +32,6 @@ using ::openpower::guard::GuardRecords;
 using Timer = sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic>;
 
 #define GUARD_RESOLVED 0xFFFFFFFF
-
 using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
 
 using Binary = std::vector<uint8_t>;

--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -339,6 +339,13 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             }
             jsonResource["CURRENT_STATE"] = std::move(state);
 
+            // getLocationCode checks if attr is present in target else
+            // gets it from partent target
+            ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+            openpower::phal::pdbg::getLocationCode(guardedTarget.target,
+                                                   attrLocCode);
+            jsonResource["LOCATION_CODE"] = attrLocCode;
+
             jsonResource["REASON_DESCRIPTION"] = getGuardReason(guardRecords,
                                                                 *physicalPath);
 


### PR DESCRIPTION
- Add missing location code tag in ResourceActions section

Tested
Ensured LOCATION_CODE is present in RESOURCE_ACTIONS section root@p10bmc:/tmp# ./faultlog -f
[
  {
    "SYSTEM": {
      "SYSTEM_SN": "139F230",
      "SYSTEM_TYPE": "9105-22B"
    }
  },
  {
    "POLICY": {
      "FCO_VALUE": 0,
      "MASTER": true,
      "PREDICTIVE": true
    }
  },
  {
    "SERVICEABLE_EVENT": [
      {
        "CEC_ERROR_LOG": [
          {
            "Callout Section": {
              "Callout Count": 1,
              "Callouts": [
                {
                  "CCIN": "5C67",
                  "Location Code": "U78DA.ND0.WZS003T-P0-C15",
                  "Part Number": "F201110",
                  "Priority": "Medium",
                  "Serial Number": "YA39AAAA1828"
                }
              ]
            },
            "DATE_TIME": "02/06/2025 05:48:11",
            "PLID": "0x50000aa9",
            "SRC": "BD13E510"
          },
          {
            "RESOURCE_ACTIONS": {
              "CURRENT_STATE": "CONFIGURED",
              "GUARD_RECORD": true,
              "LOCATION_CODE": "Ufcs-P0-C15",
              "PHYS_PATH": "physical:sys-0/node-0/proc-0/eq-1/fc-0/core-0",
              "REASON_DESCRIPTION": "UNRECOVERABLE",
              "TYPE": "POWER10 Core"
            }
          }
        ]
      }
    ]
  }
]

Change-Id: I8dc92dfd9dc55cb8ede51eff39befeed7a85ef95