### PR TITLE
faultlog: Add location code to ResourceActions

### DIFF
--- a/src/faultlog/guard_with_eid_records.cpp
+++ b/src/faultlog/guard_with_eid_records.cpp
@@ -343,7 +343,18 @@ void GuardWithEidRecords::populate(sdbusplus::bus::bus& bus,
             jsonResource["REASON_DESCRIPTION"] =
                 getGuardReason(guardRecords, *physicalPath);
 
+            // getLocationCode checks if attr is present in target else
+            // gets it from partent target
+            ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+            openpower::phal::pdbg::getLocationCode(guardedTarget.target,
+                                                   attrLocCode);
+            jsonResource["LOCATION_CODE"] = attrLocCode;
             jsonResource["GUARD_RECORD"] = true;
+            ATTR_PHYS_DEV_PATH_Type phyPath;
+            if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, guardedTarget.target, phyPath))
+            {
+                jsonResource["PHYS_PATH"] = phyPath;
+            }
 
             // An error could create single PEL but multiple guard records,
             // while processing guard records do not create multiple error log


### PR DESCRIPTION
- Add missing location code tag in ResourceActions section

Tested
Ensured LOCATION_CODE is present in RESOURCE_ACTIONS section root@p10bmc:/tmp# ./faultlog -f
[
  {
    "VERSION": 1.0
  },
  {
    "SYSTEM": {
      "SYSTEM_SN": "139F230",
      "SYSTEM_TYPE": "9105-22B"
    }
  },
  {
    "POLICY": {
      "FCO_VALUE": 0,
      "MASTER": true,
      "PREDICTIVE": true
    }
  },
  {
    "SERVICEABLE_EVENT": [
      {
        "CEC_ERROR_LOG": [
          {
            "Callout Section": {
              "Callout Count": 1,
              "Callouts": [
                {
                  "CCIN": "5C67",
                  "Location Code": "U78DA.ND0.WZS003T-P0-C15",
                  "Part Number": "F201110",
                  "Priority": "Medium",
                  "Serial Number": "YA39AAAA1828"
                }
              ]
            },
            "DATE_TIME": "02/06/2025 05:48:11",
            "PLID": "0x50000aa9",
            "SRC": "BD13E510"
          },
          {
            "RESOURCE_ACTIONS": {
              "CURRENT_STATE": "CONFIGURED",
              "GUARD_RECORD": true,
              "LOCATION_CODE": "Ufcs-P0-C15",
              "PHYS_PATH": "physical:sys-0/node-0/proc-0/eq-1/fc-0/core-0",
              "REASON_DESCRIPTION": "UNRECOVERABLE",
              "TYPE": "POWER10 Core"
            }
          }
        ]
      }
    ]
  }
]

Change-Id: I8dc92dfd9dc55cb8ede51eff39befeed7a85ef95