### PR TITLE
Fix GUI refresh and inotify handling for deleteall/clearall

### DIFF
--- a/include/common/watch.hpp
+++ b/include/common/watch.hpp
@@ -86,6 +86,16 @@ class Watch
     /* @brief Remove inotify watch and close fd's */
     ~Watch();
 
+    /** @brief removes the watch on all files and events
+     *  throws exception in case of failure
+     */
+    void removeWatch();
+
+    /** @brief add the watch on all files and events that was removed with removeWatch
+     *  throws exception in case of failure
+     */
+    void addWatch();
+
   private:
     /** @brief inotify flags */
     int _inotifyFlagsToWatch;


### PR DESCRIPTION
This change addresses the issue where the GUI did not immediately reflect cleared records after `deleteall`, causing inconsistencies. It also prevents unnecessary inotify signals during `clearall` by removing the watch before clearing and re-enabling it after updating D-Bus entries. This ensures accurate D-Bus updates and a more responsive UI.

Changes part of this commit
- Ensure GUI reflects cleared records immediately after `deleteall`, instead of waiting for guard file updates. This prevents UI inconsistencies.
- Refresh D-Bus entries with the correct record count to maintain accuracy.
- Remove inotify watch before `clearall`, since it is only allowed when the host is powered off. This prevents unnecessary inotify signals from triggering.
- Re-enable inotify watch after updating all D-Bus entries to resume normal operation.