### PR TITLE
tools: Use std::optional<std::string> directly instead of dereference

### DIFF
--- a/tools/systemguard.cpp
+++ b/tools/systemguard.cpp
@@ -189,7 +189,7 @@ int main(int argc, char **argv) {
         std::cerr << "Please enter a valid severity" << std::endl;
       }
     } else {
-      *sev = "predictive";
+      sev = "predictive";
     }
     std::cerr << "Creating System guard of type " << *sev
               << " on the target with physical path " << phyDevPath


### PR DESCRIPTION
tools: Use std::optional<std::string> directly instead of dereference
Dereferencing a std::optional (`*sev`) assumes it contains a value,
which is leading to undefined behavior. Using direct assignment  to
fix this issue.

```
Test results :

Before :
root@p10bmc:/tmp/test# sysguard -c sys-0/node-0/proc-0/eq-5/fc-0
/usr/include/c++/14.2.0/optional:475: constexpr _Tp& std::_Optional_base_impl<_Tp, _Dp>::_M_get() [with _Tp = std::__cxx11::basic_string<char>; _Dp = std::_Optional_base<std::__cxx11::basic_string<char>, false, false>]: Assertion 'this->_M_is_engaged()' failed.
Aborted (core dumped)

After:
root@p10bmc:/tmp/test# usr/bin/sysguard -c sys-0/node-0/proc-0/eq-5/fc-0
Creating System guard of type predictive on the target with physical path sys-0/node-0/proc-0/eq-5/fc-0
root@p10bmc:/tmp/test# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x50000d55 | predictive      | physical:sys-0/node-0/proc-0/eq-5/fc-0
```

Signed-off-by: Sera-Koshy <Sera.Koshy@ibm.com>