### PR TITLE
tools: Fix guard severity transition for Unrecoverable type

### DIFF
--- a/tools/systemguard.cpp
+++ b/tools/systemguard.cpp
@@ -185,7 +185,9 @@ int main(int argc, char **argv) {
       std::ranges::transform(severity, severity.begin(),
                              [](unsigned char c) { return std::tolower(c); });
       *sev = severity;
-      if (severity != "predictive" && severity != "fatal") {
+      if (severity != "predictive" && severity != "fatal" &&
+          severity != "unrecoverable")
+      {
         std::cerr << "Please enter a valid severity" << std::endl;
       }
     } else {


### PR DESCRIPTION
tools: Fix guard severity transition for Unrecoverable type

Add missing checks to allow Unrecoverable guard type transitions when overwriting existing guard records. Previously, the code only handled Fatal and Predictive guard types when determining if an existing guard record could be overwritten, causing Unrecoverable guards to be rejected.

Test Results:
```
root@p11bmc:/tmp/openpower-hw-isolation# guard -c sys-0/node-0/dimm-0
Success
root@p11bmc:/tmp/openpower-hw-isolation# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x00000000 | manual          | physical:sys-0/node-0/dimm-0
root@p11bmc:/tmp/openpower-hw-isolation# sysguard -c sys-0/node-0/dimm-0 -s unrecoverable
Creating System guard of type unrecoverable on the target with physical path sys-0/node-0/dimm-0
root@p11bmc:/tmp/openpower-hw-isolation# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x50001740 | unrecoverable   | physical:sys-0/node-0/dimm-0

root@p11bmc:/tmp/openpower-hw-isolation# guard -r
root@p11bmc:/tmp/openpower-hw-isolation# sysguard -c sys-0/node-0/dimm-0
Creating System guard of type predictive on the target with physical path sys-0/node-0/dimm-0
root@p11bmc:/tmp/openpower-hw-isolation# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x5000174e | predictive      | physical:sys-0/node-0/dimm-0
root@p11bmc:/tmp/openpower-hw-isolation# sysguard -c sys-0/node-0/dimm-0 -s Unrecoverable
Creating System guard of type unrecoverable on the target with physical path sys-0/node-0/dimm-0
root@p11bmc:/tmp/openpower-hw-isolation# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x50001755 | unrecoverable   | physical:sys-0/node-0/dimm-0
```