### PR TITLE
faultlog: Add service alerts control for nagging

### DIFF
--- a/src/faultlog/faultlog_main.cpp
+++ b/src/faultlog/faultlog_main.cpp
@@ -15,6 +15,7 @@
 #include <sdeventplus/clock.hpp>
 #include <sdeventplus/source/event.hpp>
 #include <sdeventplus/utility/timer.hpp>
+#include <service_alerts_time.hpp>
 #include <unresolved_pels.hpp>
 #include <util.hpp>
 
@@ -99,6 +100,42 @@ void createNagPel(sdbusplus::bus::bus& bus,
     // manual guard or FCO
     if ((guardCount > 0) || (unresolvedPelsCount > 0))
     {
+        // Check if service alerts are enabled before creating nag PEL
+        if (!isSendServiceAlertsEnabled(bus))
+        {
+            lg2::info("Service alerts disabled, checking for new errors");
+
+            // Check if timestamp file exists
+            auto disabledTime = readDisabledTimestamp();
+            if (!disabledTime.has_value())
+            {
+                // No timestamp file - this shouldn't happen, but treat as
+                // never disabled and re-enable
+                lg2::info(
+                    "No timestamp file found, re-enabling service alerts");
+                enableServiceAlerts(bus);
+            }
+            else
+            {
+                // Check if new errors occurred since disabled
+                if (hasNewErrorsSinceDisabled(bus, unresolvedRecords,
+                                              *disabledTime))
+                {
+                    lg2::info(
+                        "New errors detected, re-enabling service alerts");
+                    enableServiceAlerts(bus);
+                    // Continue to create PEL below
+                }
+                else
+                {
+                    lg2::info(
+                        "Service alerts disabled, skipping nag PEL creation");
+                    lg2::info("No new errors found since nagging was disabled");
+                    return; // Skip PEL creation
+                }
+            }
+        }
+
         std::unordered_map<std::string, std::string> data = {
             {"GUARD_RECORD_COUNT", std::to_string(guardCount)},
             {"PEL_WITH_DECONFIG_BIT_COUNT",
@@ -229,7 +266,7 @@ int main(int argc, char** argv)
         auto event = sdeventplus::Event::get_default();
         nlohmann::json faultLogJson = json::array();
 
-        nlohmann::json version;        
+        nlohmann::json version;
         version["VERSION"] = FAULTLOG_FORMAT_VERSION;
         faultLogJson.push_back(version);
 

--- a/src/faultlog/faultlog_policy.cpp
+++ b/src/faultlog/faultlog_policy.cpp
@@ -1,5 +1,6 @@
 #include <faultlog_policy.hpp>
 #include <phosphor-logging/lg2.hpp>
+#include <service_alerts_time.hpp>
 #include <util.hpp>
 
 namespace openpower::faultlog
@@ -52,6 +53,22 @@ void FaultLogPolicy::populate(sdbusplus::bus::bus& bus, nlohmann::json& nagJson)
         // predictive guard enabled or not
         // at present not present in BMC will leave it as true for now
         jsonPolicyVal["PREDICTIVE"] = true;
+
+        // service alerts enabled or not
+        bool serviceAlertsEnabled = true;
+        try
+        {
+            serviceAlertsEnabled = readProperty<bool>(
+                bus, "xyz.openbmc_project.Settings",
+                "/xyz/openbmc_project/hardware_isolation/send_service_alerts",
+                "xyz.openbmc_project.Object.Enable", "Enabled");
+        }
+        catch (const std::exception& ex)
+        {
+            lg2::info("Failed to read send_service_alerts property {ERROR}",
+                      "ERROR", ex);
+        }
+        jsonPolicyVal["SEND_SERVICE_ALERTS"] = serviceAlertsEnabled;
 
         json jsonPolicy = json::object();
         jsonPolicy["POLICY"] = std::move(jsonPolicyVal);

--- a/src/faultlog/faultlog_service_alerts_monitor.cpp
+++ b/src/faultlog/faultlog_service_alerts_monitor.cpp
@@ -1,0 +1,31 @@
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdeventplus/event.hpp>
+#include <service_alerts_time.hpp>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    try
+    {
+        lg2::info(
+            "faultlog service alerts monitor - watching property changes");
+        auto bus = sdbusplus::bus::new_default();
+        auto event = sdeventplus::Event::get_default();
+
+        // Start watching for service alerts property changes
+        openpower::faultlog::watchServiceAlertsProperty(bus);
+
+        // Attach bus to event loop
+        bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+
+        // Run the event loop
+        return event.loop();
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed {ERROR}", "ERROR", e.what());
+        return 1;
+    }
+}
+
+// Made with Bob

--- a/src/faultlog/meson.build
+++ b/src/faultlog/meson.build
@@ -1,16 +1,10 @@
 cpp = meson.get_compiler('cpp')
 
-sdbusplus_dep = dependency(
-    'sdbusplus',
-    fallback: ['sdbusplus', 'sdbusplus_dep'],
-)
+sdbusplus_dep = dependency('sdbusplus', fallback: ['sdbusplus', 'sdbusplus_dep'])
 
 phosphor_dbus_interfaces_dep = dependency(
     'phosphor-dbus-interfaces',
-    fallback: [
-        'phosphor-dbus-interfaces',
-        'phosphor_dbus_interfaces_dep'
-    ],  
+    fallback: ['phosphor-dbus-interfaces', 'phosphor_dbus_interfaces_dep'],
 )
 sdeventplus = dependency('sdeventplus')
 phosphor_logging_dep = dependency(
@@ -34,52 +28,73 @@ libphal = cpp.find_library('phal')
 
 systemd_dep = dependency('systemd')
 
-faultlog_sources = [ 
-        'faultlog_main.cpp',
-        'guard_with_eid_records.cpp',
-        'util.cpp',
-        'guard_without_eid_records.cpp',
-        'faultlog_policy.cpp',
-        'unresolved_pels.cpp',
-        'deconfig_records.cpp',
-        'deconfig_reason.cpp',
-        'poweron_time.cpp'
-        ]
+faultlog_sources = [
+    'faultlog_main.cpp',
+    'guard_with_eid_records.cpp',
+    'util.cpp',
+    'guard_without_eid_records.cpp',
+    'faultlog_policy.cpp',
+    'unresolved_pels.cpp',
+    'deconfig_records.cpp',
+    'deconfig_reason.cpp',
+    'poweron_time.cpp',
+    'service_alerts_time.cpp',
+]
 
-faultlog_dependencies = [ 
-        phosphor_dbus_interfaces,
-        phosphor_logging,
-        sdbusplus,
-        nlohmann_json,
-        libpdbg,
-        libdtapi,
-        libguard,
-        libphal,
-        sdeventplus
-    ]
+faultlog_dependencies = [
+    phosphor_dbus_interfaces,
+    phosphor_logging,
+    sdbusplus,
+    nlohmann_json,
+    libpdbg,
+    libdtapi,
+    libguard,
+    libphal,
+    sdeventplus,
+]
 
-executable('faultlog',
-           faultlog_sources,
-           dependencies: faultlog_dependencies,
-           include_directories: include_directories('../../'),
-           install : true
-          )
+executable(
+    'faultlog',
+    faultlog_sources,
+    dependencies: faultlog_dependencies,
+    include_directories: include_directories('../../'),
+    install: true,
+)
 
-faultlog_poweron_time_sources = [ 
-        'faultlog_poweron_time.cpp',
-        'poweron_time.cpp'
-        ]
+faultlog_poweron_time_sources = [
+    'faultlog_poweron_time.cpp',
+    'poweron_time.cpp',
+]
 
-faultlog_poweron_time_dependencies = [ 
-        phosphor_logging,
-        sdbusplus,
-        ]
+faultlog_poweron_time_dependencies = [phosphor_logging, sdbusplus]
 
-executable('faultlog-poweron-time',
-           faultlog_poweron_time_sources,
-           dependencies: faultlog_poweron_time_dependencies,
-           include_directories: include_directories('../../'),
-           install : true
-          )
+executable(
+    'faultlog-poweron-time',
+    faultlog_poweron_time_sources,
+    dependencies: faultlog_poweron_time_dependencies,
+    include_directories: include_directories('../../'),
+    install: true,
+)
+
+faultlog_service_alerts_monitor_sources = [
+    'faultlog_service_alerts_monitor.cpp',
+    'service_alerts_time.cpp',
+    'util.cpp',
+]
+
+faultlog_service_alerts_monitor_dependencies = [
+    phosphor_logging,
+    sdbusplus,
+    sdeventplus,
+    libguard,
+]
+
+executable(
+    'faultlog-service-alerts-monitor',
+    faultlog_service_alerts_monitor_sources,
+    dependencies: faultlog_service_alerts_monitor_dependencies,
+    include_directories: include_directories('../../'),
+    install: true,
+)
 
 subdir('service')

--- a/src/faultlog/service/faultlog_service_alerts_monitor.service.in
+++ b/src/faultlog/service/faultlog_service_alerts_monitor.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monitor service alerts property changes and update timestamp
+After=phosphor-settings-manager.service
+Wants=phosphor-settings-manager.service
+
+[Service]
+Restart=always
+Type=simple
+ExecStart=@bindir@/faultlog-service-alerts-monitor
+
+[Install]
+WantedBy=multi-user.target

--- a/src/faultlog/service/meson.build
+++ b/src/faultlog/service/meson.build
@@ -1,46 +1,76 @@
 systemd_system_unit_dir = systemd_dep.get_variable(
-    pkgconfig:'systemdsystemunitdir')
+    pkgconfig: 'systemdsystemunitdir',
+)
 conf_data = configuration_data()
 conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
 
-input_files = ['faultlog_periodic.service.in', 'faultlog_hostpoweron.service.in',
-        'faultlog_periodic.timer', 'faultlog_create_chassis_poweron_time.service.in']
+input_files = [
+    'faultlog_periodic.service.in',
+    'faultlog_hostpoweron.service.in',
+    'faultlog_periodic.timer',
+    'faultlog_create_chassis_poweron_time.service.in',
+    'faultlog_service_alerts_monitor.service.in',
+]
 
-output_files = ['faultlog_periodic.service', 'faultlog_hostpoweron.service',
-        'faultlog_periodic.timer', 'faultlog_create_chassis_poweron_time.service']
+output_files = [
+    'faultlog_periodic.service',
+    'faultlog_hostpoweron.service',
+    'faultlog_periodic.timer',
+    'faultlog_create_chassis_poweron_time.service',
+    'faultlog_service_alerts_monitor.service',
+]
 
 counter = 0
 foreach i : input_files
-  # Get the index of the current iteration
+    # Get the index of the current iteration
 
-  # Configure the files using configure_file()
-  configure_file(
-    input : i,
-    output : output_files[counter],
-    configuration: conf_data,
-    install: true,
-    install_dir: systemd_system_unit_dir
-  )
-  counter += 1
+    # Configure the files using configure_file()
+    configure_file(
+        input: i,
+        output: output_files[counter],
+        configuration: conf_data,
+        install: true,
+        install_dir: systemd_system_unit_dir,
+    )
+    counter += 1
 endforeach
-    
-systemd_alias = [[
-    '../faultlog_periodic.service', 'multi-user.target.wants/faultlog_periodic.service'
-]]
 
-systemd_alias += [[
-    '../faultlog_hostpoweron.service', 'obmc-host-startmin@0.target.wants/faultlog_hostpoweron.service'
-]]
+systemd_alias = [
+    [
+        '../faultlog_periodic.service',
+        'multi-user.target.wants/faultlog_periodic.service',
+    ],
+]
 
-systemd_alias += [[
-    '../faultlog_periodic.timer', 'timers.target.wants/faultlog_periodic.timer'
-]]
+systemd_alias += [
+    [
+        '../faultlog_hostpoweron.service',
+        'obmc-host-startmin@0.target.wants/faultlog_hostpoweron.service',
+    ],
+]
 
-systemd_alias += [[
-    '../faultlog_create_chassis_poweron_time.service', 'obmc-chassis-poweron@0.target.wants/faultlog_create_chassis_poweron_time.service'
-]]
+systemd_alias += [
+    [
+        '../faultlog_periodic.timer',
+        'timers.target.wants/faultlog_periodic.timer',
+    ],
+]
 
-foreach service: systemd_alias
+systemd_alias += [
+    [
+        '../faultlog_create_chassis_poweron_time.service',
+        'obmc-chassis-poweron@0.target.wants/faultlog_create_chassis_poweron_time.service',
+    ],
+]
+
+systemd_alias += [
+    [
+        '../faultlog_service_alerts_monitor.service',
+        'multi-user.target.wants/faultlog_service_alerts_monitor.service',
+    ],
+]
+
+foreach service : systemd_alias
     # Meson 0.61 will support this:
     #install_symlink(
     #      service,
@@ -48,14 +78,21 @@ foreach service: systemd_alias
     #      pointing_to: link,
     #  )
     meson.add_install_script(
-        'sh', '-c',
-        'mkdir -p $(dirname $DESTDIR/@0@/@1@)'.format(systemd_system_unit_dir,
-            service[1]),
-    )   
+        'sh',
+        '-c',
+        'mkdir -p $(dirname $DESTDIR/@0@/@1@)'.format(
+            systemd_system_unit_dir,
+            service[1],
+        ),
+    )
     meson.add_install_script(
-        'sh', '-c',
-        'ln -s @0@ $DESTDIR/@1@/@2@'.format(service[0], systemd_system_unit_dir,
-            service[1]),
-    )   
+        'sh',
+        '-c',
+        'ln -s @0@ $DESTDIR/@1@/@2@'.format(
+            service[0],
+            systemd_system_unit_dir,
+            service[1],
+        ),
+    )
 endforeach
 

--- a/src/faultlog/service_alerts_time.cpp
+++ b/src/faultlog/service_alerts_time.cpp
@@ -1,0 +1,278 @@
+#include <phosphor-logging/lg2.hpp>
+#include <service_alerts_time.hpp>
+#include <util.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <ranges>
+
+namespace openpower::faultlog
+{
+
+// Service alerts control constants
+constexpr auto SEND_SERVICE_ALERTS_PATH =
+    "/xyz/openbmc_project/hardware_isolation/send_service_alerts";
+constexpr auto SEND_SERVICE_ALERTS_IFACE = "xyz.openbmc_project.Object.Enable";
+constexpr auto NAG_DISABLED_TIMESTAMP_FILE =
+    "/var/lib/phosphor-faultlog/nag_disabled_time";
+
+bool isSendServiceAlertsEnabled(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        bool enabled = readProperty<bool>(bus, "xyz.openbmc_project.Settings",
+                                          SEND_SERVICE_ALERTS_PATH,
+                                          SEND_SERVICE_ALERTS_IFACE, "Enabled");
+        lg2::info("Service alerts status: {STATUS}", "STATUS",
+                  enabled ? "enabled" : "disabled");
+        return enabled;
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::info("Failed to read service alerts property, defaulting to "
+                  "enabled: {ERROR}",
+                  "ERROR", ex);
+        return true; // Default to enabled on error
+    }
+}
+
+void writeDisabledTimestamp(const std::string& filePath)
+{
+    const auto targetFile = filePath.empty() ? NAG_DISABLED_TIMESTAMP_FILE
+                                             : filePath;
+
+    try
+    {
+        // Ensure directory exists
+        const std::filesystem::path path(targetFile);
+        std::filesystem::create_directories(path.parent_path());
+
+        std::ofstream file(targetFile);
+        if (!file)
+        {
+            lg2::error("Failed to open timestamp file for writing");
+            return;
+        }
+
+        const auto now = std::time(nullptr);
+        file << now;
+        lg2::info("Wrote nag disabled timestamp: {TIMESTAMP}", "TIMESTAMP",
+                  now);
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("Failed to write disabled timestamp: {ERROR}", "ERROR", ex);
+    }
+}
+
+std::optional<time_t> readDisabledTimestamp(const std::string& filePath)
+{
+    const auto targetFile = filePath.empty() ? NAG_DISABLED_TIMESTAMP_FILE
+                                             : filePath;
+
+    try
+    {
+        if (!std::filesystem::exists(targetFile))
+        {
+            return std::nullopt;
+        }
+
+        std::ifstream file(targetFile);
+        if (!file)
+        {
+            return std::nullopt;
+        }
+
+        time_t timestamp{};
+        file >> timestamp;
+        lg2::info("Read nag disabled timestamp: {TIMESTAMP}", "TIMESTAMP",
+                  timestamp);
+        return timestamp;
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("Failed to read disabled timestamp: {ERROR}", "ERROR", ex);
+        return std::nullopt;
+    }
+}
+
+bool hasNewErrorsSinceDisabled(sdbusplus::bus::bus& bus,
+                               const GuardRecords& unresolvedRecords,
+                               time_t disabledTime)
+{
+    const auto disabledTimeU64 = static_cast<uint64_t>(disabledTime);
+
+    // Check guard records by looking up their associated PEL timestamps
+    for (const auto& record : unresolvedRecords)
+    {
+        // Skip manual guard records (no associated PEL)
+        if (record.elogId == 0)
+        {
+            continue;
+        }
+
+        try
+        {
+            // Get BMC log ID from PEL ID
+            auto method = bus.new_method_call(
+                "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+                "org.open_power.Logging.PEL", "GetBMCLogIdFromPELId");
+            method.append(static_cast<uint32_t>(record.elogId));
+            auto resp = bus.call(method);
+            uint32_t bmcLogId = 0;
+            resp.read(bmcLogId);
+
+            // Get PEL timestamp
+            const std::string objPath = "/xyz/openbmc_project/logging/entry/" +
+                                        std::to_string(bmcLogId);
+            auto pelMethod = bus.new_method_call(
+                "xyz.openbmc_project.Logging", objPath.c_str(),
+                "org.freedesktop.DBus.Properties", "Get");
+            pelMethod.append("org.open_power.Logging.PEL.Entry", "Timestamp");
+            auto pelReply = bus.call(pelMethod);
+            std::variant<uint64_t> timestampVariant;
+            pelReply.read(timestampVariant);
+            const auto timestamp = std::get<uint64_t>(timestampVariant);
+
+            // Convert milliseconds to seconds
+            constexpr uint64_t msToSeconds = 1000;
+            const auto timestampSeconds = timestamp / msToSeconds;
+
+            if (timestampSeconds > disabledTimeU64)
+            {
+                lg2::info("Found new guard record after nagging was disabled. "
+                          "Record ID: {RECORD_ID}, PEL ID: {ELOG_ID}, "
+                          "Timestamp: {TIMESTAMP}",
+                          "RECORD_ID", record.recordId, "ELOG_ID",
+                          record.elogId, "TIMESTAMP", timestampSeconds);
+                return true;
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            // PEL might be deleted, skip this record
+            lg2::info("Could not get timestamp for guard record {RECORD_ID}, "
+                      "PEL ID {ELOG_ID}: {ERROR}",
+                      "RECORD_ID", record.recordId, "ELOG_ID", record.elogId,
+                      "ERROR", ex);
+        }
+    }
+
+    // Check unresolved PELs with deconfig bit set (not yet guarded)
+    return checkUnresolvedPELs(bus, disabledTimeU64);
+}
+
+bool checkUnresolvedPELs(sdbusplus::bus::bus& bus, uint64_t disabledTime)
+{
+    bool foundNewPEL = false;
+
+    forEachPEL(bus, [&](const sdbusplus::message::object_path& path,
+                        const PELProperties& props) {
+        // Check if this is an unresolved, serviceable PEL
+        // Skip guarded PELs as they are captured as guard records
+        if (!props.resolved && props.deconfigured && !props.guarded &&
+            !props.hidden)
+        {
+            // Convert milliseconds to seconds and check if newer than disabled
+            // time
+            constexpr uint64_t msToSeconds = 1000;
+            const auto pelTimestampSeconds = props.timestamp / msToSeconds;
+            if (pelTimestampSeconds > disabledTime)
+            {
+                lg2::info("Found new unresolved PEL after nagging was "
+                          "disabled. Path: {PATH}, Timestamp: {TIMESTAMP}",
+                          "PATH", path.str, "TIMESTAMP", pelTimestampSeconds);
+                foundNewPEL = true;
+                return false; // Stop iteration
+            }
+        }
+        return true; // Continue iteration
+    });
+
+    return foundNewPEL;
+}
+
+void enableServiceAlerts(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Settings", SEND_SERVICE_ALERTS_PATH,
+            "org.freedesktop.DBus.Properties", "Set");
+        method.append(SEND_SERVICE_ALERTS_IFACE, "Enabled",
+                      std::variant<bool>(true));
+        auto reply = bus.call(method);
+        if (reply.is_method_error())
+        {
+            lg2::error("Failed to re-enable service alerts via D-Bus");
+        }
+        else
+        {
+            lg2::info("Service alerts re-enabled due to new errors");
+            // Remove timestamp file
+            if (std::filesystem::exists(NAG_DISABLED_TIMESTAMP_FILE))
+            {
+                std::filesystem::remove(NAG_DISABLED_TIMESTAMP_FILE);
+            }
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("Failed to enable service alerts: {ERROR}", "ERROR", ex);
+    }
+}
+
+void watchServiceAlertsProperty(sdbusplus::bus::bus& bus)
+{
+    static std::unique_ptr<sdbusplus::bus::match_t> match;
+
+    match = std::make_unique<sdbusplus::bus::match_t>(
+        bus,
+        sdbusplus::bus::match::rules::propertiesChanged(
+            SEND_SERVICE_ALERTS_PATH, SEND_SERVICE_ALERTS_IFACE),
+        [](sdbusplus::message::message& msg) {
+        std::string intf;
+        std::map<std::string, std::variant<bool>> properties;
+        msg.read(intf, properties);
+
+        const auto it = properties.find("Enabled");
+        if (it == properties.end())
+        {
+            return;
+        }
+
+        const bool enabled = std::get<bool>(it->second);
+        lg2::info("Service alerts property changed to: {STATUS}", "STATUS",
+                  enabled ? "enabled" : "disabled");
+
+        if (!enabled)
+        {
+            // ALWAYS write/update timestamp when disabled
+            writeDisabledTimestamp();
+            lg2::info("Updated nag disabled timestamp due to property change");
+        }
+        else
+        {
+            // When re-enabled, remove the timestamp file
+            try
+            {
+                if (std::filesystem::exists(NAG_DISABLED_TIMESTAMP_FILE))
+                {
+                    std::filesystem::remove(NAG_DISABLED_TIMESTAMP_FILE);
+                    lg2::info(
+                        "Removed nag disabled timestamp file - alerts enabled");
+                }
+            }
+            catch (const std::exception& ex)
+            {
+                lg2::error("Failed to remove timestamp file: {ERROR}", "ERROR",
+                           ex);
+            }
+        }
+    });
+}
+
+} // namespace openpower::faultlog
+
+// Made with Bob

--- a/src/faultlog/service_alerts_time.hpp
+++ b/src/faultlog/service_alerts_time.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <libguard/include/guard_record.hpp>
+#include <sdbusplus/bus.hpp>
+
+#include <optional>
+
+namespace openpower::faultlog
+{
+using ::openpower::guard::GuardRecords;
+
+/**
+ * @brief Check if service alerts are enabled
+ *
+ * @param[in] bus - D-Bus to attach to
+ * @return true if enabled, false if disabled (defaults to true on error)
+ */
+bool isSendServiceAlertsEnabled(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Write current timestamp to file when alerts are disabled
+ *
+ * @param[in] filePath - Path to timestamp file (optional, uses default if not
+ * provided)
+ */
+void writeDisabledTimestamp(const std::string& filePath = "");
+
+/**
+ * @brief Read the timestamp when alerts were disabled
+ *
+ * @param[in] filePath - Path to timestamp file (optional, uses default if not
+ * provided)
+ * @return std::optional<time_t> timestamp or nullopt if file doesn't exist
+ */
+std::optional<time_t> readDisabledTimestamp(const std::string& filePath = "");
+
+/**
+ * @brief Check if new hardware errors occurred after alerts were disabled
+ *
+ * Checks both guard records and unresolved PELs with deconfig bit set
+ *
+ * @param[in] bus - D-Bus to attach to
+ * @param[in] unresolvedRecords - Guard records to check
+ * @param[in] disabledTime - Time when alerts were disabled
+ * @return true if new errors exist
+ */
+bool hasNewErrorsSinceDisabled(sdbusplus::bus::bus& bus,
+                               const GuardRecords& unresolvedRecords,
+                               time_t disabledTime);
+
+/**
+ * @brief Re-enable service alerts when new errors are detected
+ *
+ * @param[in] bus - D-Bus to attach to
+ */
+void enableServiceAlerts(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Watch for service alerts property changes and update timestamp
+ *
+ * @param[in] bus - D-Bus to attach to
+ */
+void watchServiceAlertsProperty(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Check for new unresolved PELs since disabled time (internal helper)
+ *
+ * @param[in] bus - D-Bus to attach to
+ * @param[in] disabledTime - Time when alerts were disabled (in seconds)
+ * @return true if new PELs found
+ */
+bool checkUnresolvedPELs(sdbusplus::bus::bus& bus, uint64_t disabledTime);
+
+} // namespace openpower::faultlog
+
+// Made with Bob

--- a/src/faultlog/unresolved_pels.cpp
+++ b/src/faultlog/unresolved_pels.cpp
@@ -70,447 +70,190 @@ static int getGuardedTarget(struct pdbg_target* target, void* priv)
 int UnresolvedPELs::getCount(sdbusplus::bus::bus& bus, bool ignorePwrFanPel)
 {
     int count = 0;
-    try
-    {
-        Objects objects;
-        auto method = bus.new_method_call(
-            "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
-            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        auto reply = bus.call(method);
-        reply.read(objects);
 
-        // read timestamp from file
-        uint64_t poweronTimestamp = readPowerOnTime(bus);
+    // read timestamp from file
+    const uint64_t poweronTimestamp = readPowerOnTime(bus);
 
-        for (const auto& [path, interfaces] : objects)
+    forEachPEL(bus, [&](const sdbusplus::message::object_path& path,
+                        const PELProperties& props) {
+        if (props.resolved)
         {
-            bool resolved = true;
-            std::string severity =
-                "xyz.openbmc_project.Logging.Entry.Level.Informational";
-            bool deconfigured = false;
-            bool guarded = false;
-            bool hidden = false;
-            std::string refCode;
-            uint64_t timestamp = 0;
-            for (const auto& [intf, properties] : interfaces)
-            {
-                if (intf == "xyz.openbmc_project.Logging.Entry")
-                {
-                    for (const auto& [prop, propValue] : properties)
-                    {
-                        if (prop == "Resolved")
-                        {
-                            auto resolvedPtr = std::get_if<bool>(&propValue);
-                            if (resolvedPtr != nullptr)
-                            {
-                                resolved = *resolvedPtr;
-                            }
-                        }
-                        else if (prop == "Severity")
-                        {
-                            auto severityPtr =
-                                std::get_if<std::string>(&propValue);
-                            if (severityPtr != nullptr)
-                            {
-                                severity = *severityPtr;
-                            }
-                        }
-                        else if (prop == "EventId")
-                        {
-                            auto eventIdPtr =
-                                std::get_if<std::string>(&propValue);
-                            if (eventIdPtr != nullptr)
-                            {
-                                // EventId B700900B 00000072 00010016 ...
-                                // First value is RefCode
-                                std::istringstream iss(*eventIdPtr);
-                                iss >> refCode;
-                            }
-                        }
-                    }
-                }
-                else if (intf == "org.open_power.Logging.PEL.Entry")
-                {
-                    for (const auto& [prop, propValue] : properties)
-                    {
-                        if (prop == "Deconfig")
-                        {
-                            auto deconfigPtr = std::get_if<bool>(&propValue);
-                            if (deconfigPtr != nullptr)
-                            {
-                                deconfigured = *deconfigPtr;
-                            }
-                        }
-                        else if (prop == "Hidden")
-                        {
-                            auto hiddenPtr = std::get_if<bool>(&propValue);
-                            if (hiddenPtr != nullptr)
-                            {
-                                hidden = *hiddenPtr;
-                            }
-                        }
-                        else if (prop == "Guard")
-                        {
-                            auto guardPtr = std::get_if<bool>(&propValue);
-                            if (guardPtr != nullptr)
-                            {
-                                guarded = *guardPtr;
-                            }
-                        }
-                        else if (prop == "Timestamp")
-                        {
-                            auto timestampPtr =
-                                std::get_if<uint64_t>(&propValue);
-                            if (timestampPtr != nullptr)
-                            {
-                                timestamp = *timestampPtr;
-                            }
-                        }
-                    }
-                }
-            }
+            return true; // Continue
+        }
 
-            if (resolved == true)
-            {
-                continue;
-            }
+        // ignore informational and debug errors
+        if ((props.severity ==
+             "xyz.openbmc_project.Logging.Entry.Level.Debug") ||
+            (props.severity ==
+             "xyz.openbmc_project.Logging.Entry.Level.Informational") ||
+            (props.severity ==
+             "xyz.openbmc_project.Logging.Entry.Level.Notice"))
+        {
+            return true; // Continue
+        }
 
-            // ignore informational and debug errors
-            if ((severity == "xyz.openbmc_project.Logging.Entry.Level.Debug") ||
-                (severity ==
-                 "xyz.openbmc_project.Logging.Entry.Level.Informational") ||
-                (severity == "xyz.openbmc_project.Logging.Entry.Level.Notice"))
-            {
-                continue;
-            }
+        if (!props.deconfigured || props.hidden || props.guarded)
+        {
+            return true; // Continue
+        }
 
-            if (deconfigured == false)
-            {
-                continue;
-            }
+        // power and thermal err src starts with 1100
+        const bool pwrThermalErr =
+            props.refCode.substr(0, pwrThermalErrPrefix.length()) ==
+            pwrThermalErrPrefix;
 
-            if (hidden == true)
-            {
-                continue;
-            }
+        // during IPL ignore power and thermal
+        if (ignorePwrFanPel && pwrThermalErr)
+        {
+            lg2::info("Ignoring power/thermal PEL as system is IPLing {OBJECT}",
+                      "OBJECT", path.str);
+            return true; // Continue
+        }
 
-            if (guarded == true) // will be captured as part of guard records
-            {
-                continue;
-            }
+        // Ignore power and thermal pels if poweron timestamp is not found
+        if (pwrThermalErr && poweronTimestamp == 0)
+        {
+            lg2::info("Ignoring power/thermal PEL as poweron timestamp "
+                      "is not found {OBJECT}",
+                      "OBJECT", path.str);
+            return true; // Continue
+        }
 
-            // power and thermal err src starts with 1100
-            bool pwrThermalErr = false;
-            if (refCode.substr(0, pwrThermalErrPrefix.length()) ==
-                pwrThermalErrPrefix)
-            {
-                pwrThermalErr = true;
-            }
+        // Ignore PELS that are created before chassis poweron
+        if (props.timestamp < poweronTimestamp)
+        {
+            return true; // Continue
+        }
 
-            // during IPL ignore power and thermal errors
-            if (ignorePwrFanPel && pwrThermalErr)
-            {
-                lg2::info("Ignoring power/thermal PEL as system is IPLing "
-                          "{OBJECT}",
-                          "OBJECT", path.str);
-                continue;
-            }
+        count += 1;
+        return true; // Continue
+    });
 
-            // Ignore power and thermal pels if poweron timestamp is not found
-            if (pwrThermalErr && poweronTimestamp == 0)
-            {
-                lg2::info("Ignoring power/thermal PEL as poweron timestamp "
-                          "is not found {OBJECT}",
-                          "OBJECT", path.str);
-                continue;
-            }
-
-            // Ignore PELS that are created before chassis poweron
-            if (timestamp < poweronTimestamp)
-            {
-                continue;
-            }
-            count += 1;
-        } // endfor
-    }
-    catch (const sdbusplus::exception::SdBusError& ex)
-    {
-        lg2::info("There are no PELS or PEL corresponding to guard record is "
-                  "deleted "
-                  " {ERROR}",
-                  "ERROR", ex);
-    }
-    catch (const std::exception& ex)
-    {
-        lg2::error("Failed to get count of unresolved pels with deconfig bit "
-                   "set {ERROR}",
-                   "ERROR", ex);
-    }
     return count;
 }
 
 void UnresolvedPELs::populate(sdbusplus::bus::bus& bus,
                               const GuardRecords& guardRecords, json& jsonNag)
 {
-    try
-    {
-        Objects objects;
-        auto method = bus.new_method_call(
-            "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
-            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-        auto reply = bus.call(method);
-        reply.read(objects);
+    const uint64_t poweronTimestamp = readPowerOnTime(bus);
 
-        uint64_t poweronTimestamp = readPowerOnTime(bus);
-
-        for (const auto& [path, interfaces] : objects)
+    forEachPEL(bus, [&](const sdbusplus::message::object_path& path,
+                        const PELProperties& props) {
+        if (props.resolved)
         {
-            bool resolved = true;
-            std::string severity =
-                "xyz.openbmc_project.Logging.Entry.Level.Informational";
-            uint32_t plid = 0;
-            bool deconfigured = false;
-            bool guarded = false;
-            bool hidden = false;
-            uint64_t timestamp = 0;
-            std::string callouts;
-            std::string refCode;
-            for (const auto& [intf, properties] : interfaces)
-            {
-                if (intf == "xyz.openbmc_project.Logging.Entry")
-                {
-                    for (const auto& [prop, propValue] : properties)
-                    {
-                        if (prop == "Resolved")
-                        {
-                            auto resolvedPtr = std::get_if<bool>(&propValue);
-                            if (resolvedPtr != nullptr)
-                            {
-                                resolved = *resolvedPtr;
-                            }
-                        }
-                        else if (prop == "Severity")
-                        {
-                            auto severityPtr =
-                                std::get_if<std::string>(&propValue);
-                            if (severityPtr != nullptr)
-                            {
-                                severity = *severityPtr;
-                            }
-                        }
-                        else if (prop == "Resolution")
-                        {
-                            auto calloutsPtr =
-                                std::get_if<std::string>(&propValue);
-                            if (calloutsPtr != nullptr)
-                            {
-                                callouts = *calloutsPtr;
-                            }
-                        }
-                        else if (prop == "EventId")
-                        {
-                            auto eventIdPtr =
-                                std::get_if<std::string>(&propValue);
-                            if (eventIdPtr != nullptr)
-                            {
-                                // EventId B700900B 00000072 ...
-                                // First value is RefCode
-                                std::istringstream iss(*eventIdPtr);
-                                iss >> refCode;
-                            }
-                        }
-                    }
-                }
-                else if (intf == "org.open_power.Logging.PEL.Entry")
-                {
-                    for (const auto& [prop, propValue] : properties)
-                    {
-                        if (prop == "PlatformLogID")
-                        {
-                            auto plidPtr = std::get_if<uint32_t>(&propValue);
-                            if (plidPtr != nullptr)
-                            {
-                                plid = *plidPtr;
-                            }
-                        }
-                        else if (prop == "Deconfig")
-                        {
-                            auto deconfigPtr = std::get_if<bool>(&propValue);
-                            if (deconfigPtr != nullptr)
-                            {
-                                deconfigured = *deconfigPtr;
-                            }
-                        }
-                        else if (prop == "Guard")
-                        {
-                            auto guardPtr = std::get_if<bool>(&propValue);
-                            if (guardPtr != nullptr)
-                            {
-                                guarded = *guardPtr;
-                            }
-                        }
-                        else if (prop == "Timestamp")
-                        {
-                            auto timestampPtr =
-                                std::get_if<uint64_t>(&propValue);
-                            if (timestampPtr != nullptr)
-                            {
-                                timestamp = *timestampPtr;
-                            }
-                        }
-                        else if (prop == "Hidden")
-                        {
-                            auto hiddenPtr = std::get_if<bool>(&propValue);
-                            if (hiddenPtr != nullptr)
-                            {
-                                hidden = *hiddenPtr;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (resolved == true)
-            {
-                continue;
-            }
-
-            // ignore informational and debug errors
-            if ((severity == "xyz.openbmc_project.Logging.Entry.Level.Debug") ||
-                (severity == "xyz.openbmc_project.Logging.Entry.Level."
-                             "Informational") ||
-                (severity == "xyz.openbmc_project.Logging.Entry.Level.Notice"))
-            {
-                continue;
-            }
-
-            if (deconfigured == false)
-            {
-                continue;
-            }
-
-            if (guarded == true)
-            {
-                continue; // will be captured as part of guard records
-            }
-
-            if (hidden == true)
-            {
-                continue;
-            }
-
-            // power and thermal err src starts with 1100
-            bool pwrThermalErr = false;
-            if (refCode.substr(0, pwrThermalErrPrefix.length()) ==
-                pwrThermalErrPrefix)
-            {
-                pwrThermalErr = true;
-            }
-
-            // Ignore power and thermal pels if poweron timestamp is not found
-            if (pwrThermalErr && poweronTimestamp == 0)
-            {
-                lg2::debug("Ignoring power/thermal PEL as poweron timestamp "
-                           "is not found {OBJECT}",
-                           "OBJECT", path.str);
-                continue;
-            }
-
-            // Ignore PELS that are created before chassis poweron
-            if (timestamp < poweronTimestamp)
-            {
-                lg2::debug("Ignoring PEL created before chassis "
-                           "poweron {OBJECT}",
-                           "OBJECT", path.str);
-                continue;
-            }
-
-            // add cec errorlog
-            json jsonErrorLog = json::object();
-            std::stringstream ss;
-            ss << std::hex << "0x" << plid;
-            jsonErrorLog["PLID"] = ss.str();
-            jsonErrorLog["Callout Section"] = parseCallout(callouts);
-            jsonErrorLog["SRC"] = refCode;
-            jsonErrorLog["DATE_TIME"] = epochTimeToBCD(timestamp);
-
-            json jsonErrorLogSection = json::array();
-            jsonErrorLogSection.push_back(std::move(jsonErrorLog));
-
-            // add resource action check if guard record is found
-            json jsonResource = json::object();
-            for (const auto& elem : guardRecords)
-            {
-                if (elem.elogId == plid)
-                {
-                    auto physicalPath =
-                        openpower::guard::getPhysicalPath(elem.targetId);
-                    GuardedTarget guardedTarget(*physicalPath);
-                    pdbg_target_traverse(nullptr, getGuardedTarget,
-                                         &guardedTarget);
-                    if (guardedTarget.target == nullptr)
-                    {
-                        lg2::info("Failed to find the pdbg target for "
-                                  "guarded "
-                                  "target {RECORD_ID}",
-                                  "RECORD_ID", elem.recordId);
-                        continue;
-                    }
-                    jsonResource["TYPE"] = pdbgTargetName(guardedTarget.target);
-                    std::string state = stateDeconfigured;
-                    ATTR_HWAS_STATE_Type hwasState;
-                    if (!DT_GET_PROP(ATTR_HWAS_STATE, guardedTarget.target,
-                                     hwasState))
-                    {
-                        if (hwasState.functional)
-                        {
-                            state = stateConfigured;
-                        }
-                    }
-                    jsonResource["CURRENT_STATE"] = std::move(state);
-
-                    // getLocationCode checks if attr is present in target else
-                    // gets it from partent target
-                    ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
-                    openpower::phal::pdbg::getLocationCode(guardedTarget.target,
-                                                           attrLocCode);
-                    jsonResource["LOCATION_CODE"] = attrLocCode;
-
-                    jsonResource["REASON_DESCRIPTION"] =
-                        getGuardReason(guardRecords, *physicalPath);
-
-                    jsonResource["GUARD_RECORD"] = true;
-                    ATTR_PHYS_DEV_PATH_Type phyPath;
-                    if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, guardedTarget.target,
-                                     phyPath))
-                    {
-                        jsonResource["PHYS_PATH"] = phyPath;
-                    }
-
-                    break;
-                }
-            } // endfor
-            json jsonEventData = json::object();
-            jsonEventData["RESOURCE_ACTIONS"] = std::move(jsonResource);
-            jsonErrorLogSection.push_back(jsonEventData);
-
-            json jsonErrlogObj = json::object();
-            jsonErrlogObj["CEC_ERROR_LOG"] = std::move(jsonErrorLogSection);
-            jsonNag.emplace_back(jsonErrlogObj);
+            return true; // Continue
         }
-    }
-    catch (const sdbusplus::exception::SdBusError& ex)
-    {
-        lg2::info("There are no PELS or PEL corresponding to guard record is "
-                  "deleted "
-                  " {ERROR}",
-                  "ERROR", ex);
-    }
-    catch (const std::exception& ex)
-    {
-        lg2::error("Failed to add unresolved pels with deconfig bit "
-                   "set {ERROR}",
-                   "ERROR", ex);
-    }
+
+        // ignore informational and debug errors
+        if ((props.severity ==
+             "xyz.openbmc_project.Logging.Entry.Level.Debug") ||
+            (props.severity ==
+             "xyz.openbmc_project.Logging.Entry.Level.Informational") ||
+            (props.severity ==
+             "xyz.openbmc_project.Logging.Entry.Level.Notice"))
+        {
+            return true; // Continue
+        }
+
+        if (!props.deconfigured || props.guarded || props.hidden)
+        {
+            return true; // Continue
+        }
+
+        // power and thermal err src starts with 1100
+        const bool pwrThermalErr =
+            props.refCode.substr(0, pwrThermalErrPrefix.length()) ==
+            pwrThermalErrPrefix;
+
+        // Ignore power and thermal pels if poweron timestamp is not found
+        if (pwrThermalErr && poweronTimestamp == 0)
+        {
+            lg2::debug("Ignoring power/thermal PEL as poweron timestamp "
+                       "is not found {OBJECT}",
+                       "OBJECT", path.str);
+            return true; // Continue
+        }
+
+        // Ignore PELS that are created before chassis poweron
+        if (props.timestamp < poweronTimestamp)
+        {
+            lg2::debug("Ignoring PEL created before chassis poweron {OBJECT}",
+                       "OBJECT", path.str);
+            return true; // Continue
+        }
+
+        // add cec errorlog
+        json jsonErrorLog = json::object();
+        std::stringstream ss;
+        ss << std::hex << "0x" << props.plid;
+        jsonErrorLog["PLID"] = ss.str();
+        jsonErrorLog["Callout Section"] = parseCallout(props.callouts);
+        jsonErrorLog["SRC"] = props.refCode;
+        jsonErrorLog["DATE_TIME"] = epochTimeToBCD(props.timestamp);
+
+        json jsonErrorLogSection = json::array();
+        jsonErrorLogSection.push_back(std::move(jsonErrorLog));
+
+        // add resource action check if guard record is found
+        json jsonResource = json::object();
+        for (const auto& elem : guardRecords)
+        {
+            if (elem.elogId == props.plid)
+            {
+                auto physicalPath =
+                    openpower::guard::getPhysicalPath(elem.targetId);
+                GuardedTarget guardedTarget(*physicalPath);
+                pdbg_target_traverse(nullptr, getGuardedTarget, &guardedTarget);
+                if (guardedTarget.target == nullptr)
+                {
+                    lg2::info("Failed to find the pdbg target for guarded "
+                              "target {RECORD_ID}",
+                              "RECORD_ID", elem.recordId);
+                    continue;
+                }
+                jsonResource["TYPE"] = pdbgTargetName(guardedTarget.target);
+                std::string state = stateDeconfigured;
+                ATTR_HWAS_STATE_Type hwasState;
+                if (!DT_GET_PROP(ATTR_HWAS_STATE, guardedTarget.target,
+                                 hwasState))
+                {
+                    if (hwasState.functional)
+                    {
+                        state = stateConfigured;
+                    }
+                }
+                jsonResource["CURRENT_STATE"] = std::move(state);
+
+                // getLocationCode checks if attr is present in target else
+                // gets it from parent target
+                ATTR_LOCATION_CODE_Type attrLocCode = {'\0'};
+                openpower::phal::pdbg::getLocationCode(guardedTarget.target,
+                                                       attrLocCode);
+                jsonResource["LOCATION_CODE"] = attrLocCode;
+
+                jsonResource["REASON_DESCRIPTION"] =
+                    getGuardReason(guardRecords, *physicalPath);
+
+                jsonResource["GUARD_RECORD"] = true;
+                ATTR_PHYS_DEV_PATH_Type phyPath;
+                if (!DT_GET_PROP(ATTR_PHYS_DEV_PATH, guardedTarget.target,
+                                 phyPath))
+                {
+                    jsonResource["PHYS_PATH"] = phyPath;
+                }
+
+                break;
+            }
+        }
+        json jsonEventData = json::object();
+        jsonEventData["RESOURCE_ACTIONS"] = std::move(jsonResource);
+        jsonErrorLogSection.push_back(jsonEventData);
+
+        json jsonErrlogObj = json::object();
+        jsonErrlogObj["CEC_ERROR_LOG"] = std::move(jsonErrorLogSection);
+        jsonNag.emplace_back(jsonErrlogObj);
+
+        return true; // Continue
+    });
 }
 } // namespace openpower::faultlog

--- a/src/faultlog/util.cpp
+++ b/src/faultlog/util.cpp
@@ -105,7 +105,7 @@ json parseCallout(const std::string callout)
 
     // Regular expression to capture key-value pairs (ignores the starting
     // number)
-    // Example 
+    // Example
     // 1. LocationCode:xxxx, CCIN:XXX, SN:xxxx, PN:xxxx, Priority:xxx
     // 2. PN:xxxx, Priority:xxx
     std::regex pattern(
@@ -117,7 +117,7 @@ json parseCallout(const std::string callout)
     while (std::getline(stream, line))
     {
         if (!line.empty())
-        { // Ignore empty lines
+        {                    // Ignore empty lines
             lineCount += 1;
             json jsonObject; // JSON object to hold key-value pairs
             std::smatch matches;
@@ -197,6 +197,135 @@ std::string pdbgTargetName(struct pdbg_target* target)
     }
     auto trgtName = pdbg_target_name(target);
     return (trgtName ? trgtName : "");
+}
+
+bool forEachPEL(sdbusplus::bus::bus& bus,
+                std::function<bool(const sdbusplus::message::object_path&,
+                                   const PELProperties&)>
+                    callback)
+{
+    try
+    {
+        using PropertyValue =
+            std::variant<std::string, bool, uint8_t, int16_t, uint16_t, int32_t,
+                         uint32_t, int64_t, uint64_t, double>;
+        using Properties = std::map<std::string, PropertyValue>;
+        using Interfaces = std::map<std::string, Properties>;
+        using Objects = std::map<sdbusplus::message::object_path, Interfaces>;
+
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+        auto reply = bus.call(method);
+
+        Objects objects;
+        reply.read(objects);
+
+        for (const auto& [path, interfaces] : objects)
+        {
+            PELProperties props;
+
+            // Parse logging entry interface
+            for (const auto& [intf, properties] : interfaces)
+            {
+                if (intf == "xyz.openbmc_project.Logging.Entry")
+                {
+                    for (const auto& [prop, propValue] : properties)
+                    {
+                        if (prop == "Resolved")
+                        {
+                            if (const auto* ptr = std::get_if<bool>(&propValue))
+                            {
+                                props.resolved = *ptr;
+                            }
+                        }
+                        else if (prop == "Severity")
+                        {
+                            if (const auto* ptr =
+                                    std::get_if<std::string>(&propValue))
+                            {
+                                props.severity = *ptr;
+                            }
+                        }
+                        else if (prop == "EventId")
+                        {
+                            if (const auto* ptr =
+                                    std::get_if<std::string>(&propValue))
+                            {
+                                // EventId B700900B 00000072 00010016 ...
+                                // First value is RefCode
+                                std::istringstream iss(*ptr);
+                                iss >> props.refCode;
+                            }
+                        }
+                        else if (prop == "Resolution")
+                        {
+                            if (const auto* ptr =
+                                    std::get_if<std::string>(&propValue))
+                            {
+                                props.callouts = *ptr;
+                            }
+                        }
+                    }
+                }
+                else if (intf == "org.open_power.Logging.PEL.Entry")
+                {
+                    for (const auto& [prop, propValue] : properties)
+                    {
+                        if (prop == "PlatformLogID")
+                        {
+                            if (const auto* ptr =
+                                    std::get_if<uint32_t>(&propValue))
+                            {
+                                props.plid = *ptr;
+                            }
+                        }
+                        else if (prop == "Deconfig")
+                        {
+                            if (const auto* ptr = std::get_if<bool>(&propValue))
+                            {
+                                props.deconfigured = *ptr;
+                            }
+                        }
+                        else if (prop == "Guard")
+                        {
+                            if (const auto* ptr = std::get_if<bool>(&propValue))
+                            {
+                                props.guarded = *ptr;
+                            }
+                        }
+                        else if (prop == "Hidden")
+                        {
+                            if (const auto* ptr = std::get_if<bool>(&propValue))
+                            {
+                                props.hidden = *ptr;
+                            }
+                        }
+                        else if (prop == "Timestamp")
+                        {
+                            if (const auto* ptr =
+                                    std::get_if<uint64_t>(&propValue))
+                            {
+                                props.timestamp = *ptr;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Invoke callback - if it returns false, stop iteration
+            if (!callback(path, props))
+            {
+                return true;
+            }
+        }
+        return true;
+    }
+    catch (const std::exception& ex)
+    {
+        lg2::error("Failed to iterate PELs: {ERROR}", "ERROR", ex);
+        return false;
+    }
 }
 
 } // namespace openpower::faultlog

--- a/src/faultlog/util.hpp
+++ b/src/faultlog/util.hpp
@@ -104,4 +104,33 @@ bool isECOcore(struct pdbg_target* target);
  * @return name of the target
  */
 std::string pdbgTargetName(struct pdbg_target* target);
+
+/**
+ * @brief Structure to hold PEL properties
+ */
+struct PELProperties
+{
+    bool resolved{true};
+    bool deconfigured{false};
+    bool guarded{false};
+    bool hidden{false};
+    uint64_t timestamp{0};
+    uint32_t plid{0};
+    std::string severity;
+    std::string refCode;
+    std::string callouts;
+};
+
+/**
+ * @brief Iterate through all PELs and invoke callback for each
+ *
+ * @param[in] bus - D-Bus handle
+ * @param[in] callback - Function to call for each PEL with path and properties
+ * @return true if iteration completed successfully
+ */
+bool forEachPEL(sdbusplus::bus::bus& bus,
+                std::function<bool(const sdbusplus::message::object_path&,
+                                   const PELProperties&)>
+                    callback);
+
 } // namespace openpower::faultlog


### PR DESCRIPTION
Implement a feature to disable/enable periodic service alert nagging for hardware isolation events. When disabled, alerts are suppressed until new hardware failures are detected, at which point alerts are automatically re-enabled.

Key Features:
- D-Bus property to control service alerts (send_service_alerts)
- Timestamp tracking when alerts are disabled
- Automatic re-enabling when new hardware errors occur
- Checks both guard records and unresolved PELs for new errors
- Continuous monitoring service for property changes
- Unit tests for core functionality


Change-Id: I695f7e03f48a383124db81235deb131b2b654a84